### PR TITLE
Phase 1: split simplify_network into aggregate_to_substations + cluster_simpl

### DIFF
--- a/docs/source/config-configuration.md
+++ b/docs/source/config-configuration.md
@@ -343,10 +343,6 @@ Cleaned and labeled REeDs Shapes are pulled from this github repository: https:/
 ```
 
 
-```{note}
-`feature:` in `simplify_network:` are only relevant if `hac` were chosen in `algorithm`.
-```
-
 ```{tip}
 use `min` in `p_nom_max:` for more conservative assumptions.
 ```

--- a/docs/source/configtables/clustering.csv
+++ b/docs/source/configtables/clustering.csv
@@ -1,13 +1,10 @@
-﻿,Unit,Value,Description
+,Unit,Value,Description
 simplify_network:,,,
 weighting_strategy,str,"{population, demand-capacity}","When building multiple networks, Use 'population' if you want to ensure the clusters are assigned constant names."
-to_substations,bool,"{true, false}",Implementation curerntly overrides to true. Network is simplified to substation nodes with positive or negative power injection.
-algorithm,str,{'kmeans'},
-feature,str," {'solar+onwind-time', 'solar+onwind-cap', 'solar-time', 'solar-cap', 'solar+offwind-cap'}",For HAC clustering.
+algorithm,str,"{kmeans, modularity}",
 cluster_network:,,,
 weighting_strategy,str,"{population, demand-capacity}","When building multiple networks, Use 'population' if you want to ensure the clusters are assigned constant names."
-algorithm,str,{'kmeans'},
-feature,str," {'solar+onwind-time', 'solar+onwind-cap', 'solar-time', 'solar-cap', 'solar+offwind-cap'}",For HAC clustering.
+algorithm,str,"{kmeans, modularity}",
 aggregation_strategies:,,,
 table --> {key},str,"{'mean','max','min',etc}","Specifiy the method of aggregating fields within the generators, buses tables. "
 focus_weights:,,,

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -199,13 +199,10 @@ costs:
 clustering:
   simplify_network:
     weighting_strategy: demand-capacity # choose from: [population, demand-capacity]
-    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
-    algorithm: kmeans # choose from: [hac, kmeans]
-    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    algorithm: kmeans # choose from: [kmeans, modularity]
   cluster_network:
     weighting_strategy: demand-capacity # choose from: [population, demand-capacity]
-    algorithm: kmeans # choose from: [hac, kmeans]
-    feature: solar+onwind-time
+    algorithm: kmeans # choose from: [kmeans, modularity]
     exclude_carriers: []
     consider_efficiency_classes: false
   aggregation_strategies:

--- a/workflow/repo_data/config/config.tutorial.yaml
+++ b/workflow/repo_data/config/config.tutorial.yaml
@@ -162,12 +162,9 @@ sector:
 # docs :
 clustering:
   simplify_network:
-    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
-    algorithm: kmeans # choose from: [hac, kmeans]
-    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    algorithm: kmeans # choose from: [kmeans, modularity]
   cluster_network:
-    algorithm: kmeans # choose from: [hac, kmeans]
-    feature: solar+onwind-time
+    algorithm: kmeans # choose from: [kmeans, modularity]
     exclude_carriers: []
     consider_efficiency_classes: false
   aggregation_strategies:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -740,12 +740,9 @@ rule add_electricity:
 
 
 ################# ----------- Rules to Aggregate & Simplify Network ---------- #################
-rule simplify_network:
+rule aggregate_to_substations:
     params:
         aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
-        focus_weights=config_provider("focus_weights", default=False),
-        simplify_network=config_provider("clustering", "simplify_network"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
         topological_boundaries=config_provider(
             "model_topology", "topological_boundaries"
         ),
@@ -753,6 +750,29 @@ rule simplify_network:
         bus2sub=RESOURCES + "{interconnect}/bus2sub.csv",
         sub=RESOURCES + "{interconnect}/sub.csv",
         network=RESOURCES + "{interconnect}/elec_base_network_l_pp.pkl",
+    output:
+        network=RESOURCES + "{interconnect}/elec_b.nc",
+        busmap=RESOURCES + "{interconnect}/busmap_b.csv",
+    log:
+        "logs/aggregate_to_substations/{interconnect}.log",
+    threads: 1
+    resources:
+        mem_mb=lambda wildcards, input, attempt: (input.size // 150000) * attempt * 1.5,
+        walltime=config_provider(
+            "walltime", "aggregate_to_substations", default="01:00:00"
+        ),
+    script:
+        "../scripts/aggregate_to_substations.py"
+
+
+rule cluster_simpl:
+    params:
+        aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
+        focus_weights=config_provider("focus_weights", default=False),
+        simplify_network=config_provider("clustering", "simplify_network"),
+        planning_horizons=config_provider("scenario", "planning_horizons"),
+    input:
+        network=RESOURCES + "{interconnect}/elec_b.nc",
         regions_onshore=RESOURCES + "{interconnect}/Geospatial/regions_onshore.geojson",
         regions_offshore=RESOURCES
         + "{interconnect}/Geospatial/regions_offshore.geojson",
@@ -763,13 +783,13 @@ rule simplify_network:
         regions_offshore=RESOURCES
         + "{interconnect}/Geospatial/regions_offshore_s{simpl}.geojson",
     log:
-        "logs/simplify_network/{interconnect}/elec_s{simpl}.log",
+        "logs/cluster_simpl/{interconnect}/elec_s{simpl}.log",
     threads: 1
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 150000) * attempt * 1.5,
-        walltime=config_provider("walltime", "simplify_network", default="01:00:00"),
+        walltime=config_provider("walltime", "cluster_simpl", default="01:00:00"),
     script:
-        "../scripts/simplify_network.py"
+        "../scripts/cluster_simpl.py"
 
 
 rule cluster_network:

--- a/workflow/scripts/aggregate_to_substations.py
+++ b/workflow/scripts/aggregate_to_substations.py
@@ -1,64 +1,53 @@
 # BY PyPSA-USA Authors
-"""Aggregates network to substations and simplifies to a single voltage level."""
+"""Aggregates the full nodal network to substation level and normalizes to one voltage.
+
+First stage of the topology-aggregation pipeline (formerly the first half of
+``simplify_network.py``). Consumes the full nodal network produced by
+``add_electricity`` and reduces it to one bus per substation via:
+
+1. Converting line parameters to a single voltage base (230 kV).
+2. Removing transformers, collapsing voltage layers into a single bus per
+   substation.
+3. Aggregating buses by ``sub_id``.
+
+The downstream ``cluster_simpl`` rule may then optionally apply k-means
+clustering to ``{simpl}`` clusters.
+"""
 
 import logging
-from functools import reduce
 
 import dill as pickle
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, update_p_nom_max
-from cluster_network import cluster_regions, clustering_for_n_clusters
+from _helpers import configure_logging
 from pypsa.clustering.spatial import get_clustering_from_busmap
 
 logger = logging.getLogger(__name__)
 
 
 def convert_to_per_unit(df):
-    # Calculating base values per component
     df["base_impedance"] = df["v_nom"] ** 2 / df["s_nom"]
     df["base_susceptance"] = 1 / df["base_impedance"]
-
-    # Converting to per-unit values
     df["resistance_pu"] = df["r"] / df["base_impedance"]
     df["reactance_pu"] = df["x"] / df["base_impedance"]
     df["susceptance_pu"] = df["b"] / df["base_susceptance"]
-
-    # Dropping intermediate columns (optional)
     df = df.drop(["base_impedance", "base_susceptance"], axis=1)
-
     return df
 
 
 def convert_to_voltage_level(n, new_voltage):
-    """
-    Converts network.lines parameters to a given voltage.
-
-    Parameters
-    ----------
-    n (pypsa.Network): Network
-    new_voltage (float): New voltage level
-    """
+    """Convert network.lines parameters to a given voltage."""
     df = convert_to_per_unit(n.lines.copy())
-
     df["new_base_impedance"] = new_voltage**2 / df["s_nom"]
-
-    # Convert per-unit values back to actual values using the new base impedance
     df["r"] = df["resistance_pu"] * df["new_base_impedance"]
     df["x"] = df["reactance_pu"] * df["new_base_impedance"]
     df["b"] = df["susceptance_pu"] / df["new_base_impedance"]
-
     df.v_nom = new_voltage
-
-    # Dropping intermediate column
     df = df.drop(
         ["new_base_impedance", "resistance_pu", "reactance_pu", "susceptance_pu"],
         axis=1,
     )
-
-    # Update network lines
     df.type = "Al/St 240/40 2-bundle 220.0"
     n.buses["v_nom"] = new_voltage
     n.lines = df
@@ -146,7 +135,7 @@ def aggregate_to_substations(
     network_s.buses["x"] = substations.x
     network_s.buses["y"] = substations.y
     network_s.buses["substation_lv"] = True
-    network_s.buses["country"] = zone  # country field used bc pypsa algo aggregates based on country field
+    network_s.buses["country"] = zone  # `country` field drives pypsa aggregation grouping
 
     network_s.lines["type"] = np.nan
 
@@ -184,20 +173,14 @@ def aggregate_to_substations(
             "reeds_state",
         ]
 
-    # Only drop columns that exist in the DataFrame
     cols2drop = [col for col in cols2drop if col in network_s.buses.columns]
     network_s.buses = network_s.buses.drop(columns=cols2drop)
     return network_s, clustering.busmap
 
 
 def assign_line_lengths(n, line_length_factor):
-    """
-    Assign line lengths to network.
-
-    Uses haversine function to calculate line lengths.
-    """
+    """Assign line lengths to network using haversine."""
     logger.info("Assigning line lengths using haversine function...")
-
     n.lines.length = pypsa.geo.haversine_pts(
         n.buses.loc[n.lines.bus0][["x", "y"]],
         n.buses.loc[n.lines.bus1][["x", "y"]],
@@ -218,22 +201,19 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "simplify_network",
+            "aggregate_to_substations",
             interconnect="texas",
-            simpl="50",
         )
     configure_logging(snakemake)
     params = snakemake.params
-    solver_name = snakemake.config["solving"]["solver"]["name"]
 
     topological_boundaries = snakemake.params.topological_boundaries
 
-    # n = pypsa.Network(snakemake.input.network)
     n = pickle.load(open(snakemake.input.network, "rb"))
 
     n.generators = n.generators.drop(
         columns=["ba_eia"],
-    )  # temp added these columns and need to drop for workflow
+    )  # temp columns added in build_powerplants; drop for downstream
 
     n = convert_to_voltage_level(n, 230)
     n, trafo_map = remove_transformers(n)
@@ -241,14 +221,10 @@ if __name__ == "__main__":
     substations = pd.read_csv(snakemake.input.sub, index_col=0)
     substations.index = substations.index.astype(str)
 
-    # new busmap definition
     busmap_to_sub = n.buses.sub_id.astype(int).astype(str).to_frame()
-    busmaps = [trafo_map, busmap_to_sub.sub_id]
-    busmaps = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
 
-    n = assign_line_lengths(n, 1.25)  # Eventually replace with GIS analysis.
+    n = assign_line_lengths(n, 1.25)
     n.links["underwater_fraction"] = 0
-
     n.buses.drop(columns=["substation_off"], inplace=True)
 
     n, busmap = aggregate_to_substations(
@@ -262,47 +238,5 @@ if __name__ == "__main__":
     if topological_boundaries in ["reeds_zone", "state"] and "county" in n.buses.columns:
         n.buses = n.buses.drop(columns=["county"])
 
-    if snakemake.wildcards.simpl:
-        n.set_investment_periods(periods=snakemake.params.planning_horizons)
-
-        n.loads_t.p = n.loads_t.p.iloc[:, 0:0]
-        n.loads_t.q = n.loads_t.q.iloc[:, 0:0]
-        attr = [
-            "p",
-            "q",
-            "state_of_charge",
-            "mu_state_of_charge_set",
-            "mu_energy_balance",
-            "mu_lower",
-            "mu_upper",
-            "spill",
-            "p_dispatch",
-            "p_store",
-        ]
-        for attr in attr:
-            n.storage_units_t[attr] = n.storage_units_t[attr].iloc[:, 0:0]
-
-        # Patch for bug where pypsa io clustering will add incorrect build_years for new gens
-        n.generators.build_year += 0.001
-
-        clustering = clustering_for_n_clusters(
-            n,
-            int(snakemake.wildcards.simpl),
-            focus_weights=params.focus_weights,
-            solver_name=solver_name,
-            algorithm=params.simplify_network["algorithm"],
-            feature=params.simplify_network["feature"],
-            aggregation_strategies=params.aggregation_strategies,
-            weighting_strategy=params.simplify_network.get("weighting_strategy", None),
-        )
-        n = clustering.network
-
-        cluster_regions((clustering.busmap,), snakemake.input, snakemake.output)
-    else:
-        for which in ("regions_onshore", "regions_offshore"):  # pass through regions
-            regions = gpd.read_file(getattr(snakemake.input, which))
-            regions.to_file(getattr(snakemake.output, which))
-
-    update_p_nom_max(n)
-
-    n.export_to_netcdf(snakemake.output[0])
+    n.export_to_netcdf(snakemake.output.network)
+    busmap.to_csv(snakemake.output.busmap, header=["sub_id"])

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -22,7 +22,6 @@ from add_electricity import update_transmission_costs
 from constants import REEDS_NERC_INTERCONNECT_MAPPER, STATES_INTERCONNECT_MAPPER
 from pypsa.clustering.spatial import (
     busmap_by_greedy_modularity,
-    busmap_by_hac,
     busmap_by_kmeans,
     get_clustering_from_busmap,
 )
@@ -65,46 +64,6 @@ def weighting_for_region(n, x, weighting_strategy=None):
         weighting = normed(n.buses.loc[x.index].Pd)
 
     return (weighting * (100.0 / weighting.max())).clip(lower=1.0).astype(int)
-
-
-def get_feature_for_hac(n, buses_i=None, feature=None):
-    if buses_i is None:
-        buses_i = n.buses.index
-
-    if feature is None:
-        feature = "solar+onwind-time"
-
-    carriers = feature.split("-")[0].split("+")
-    if "offwind" in carriers:
-        carriers.remove("offwind")
-        carriers = np.append(
-            carriers,
-            n.generators.carrier.filter(like="offwind").unique(),
-        )
-
-    if feature.split("-")[1] == "cap":
-        feature_data = pd.DataFrame(index=buses_i, columns=carriers)
-        for carrier in carriers:
-            gen_i = n.generators.query("carrier == @carrier").index
-            attach = n.generators_t.p_max_pu[gen_i].mean().rename(index=n.generators.loc[gen_i].bus)
-            feature_data[carrier] = attach
-
-    if feature.split("-")[1] == "time":
-        feature_data = pd.DataFrame(columns=buses_i)
-        for carrier in carriers:
-            gen_i = n.generators.query("carrier == @carrier").index
-            attach = n.generators_t.p_max_pu[gen_i].rename(
-                columns=n.generators.loc[gen_i].bus,
-            )
-            feature_data = pd.concat([feature_data, attach], axis=0)[buses_i]
-
-        feature_data = feature_data.T
-        # timestamp raises error in sklearn >= v1.2:
-        feature_data.columns = feature_data.columns.astype(str)
-
-    feature_data = feature_data.fillna(0)
-
-    return feature_data
 
 
 def distribute_clusters(
@@ -179,7 +138,6 @@ def busmap_for_n_clusters(
     solver_name,
     focus_weights=None,
     algorithm="kmeans",
-    feature=None,
     weighting_strategy=None,
     **algorithm_kwds,
 ):
@@ -205,46 +163,9 @@ def busmap_for_n_clusters(
         algorithm_kwds.setdefault("tol", 1e-6)
         algorithm_kwds.setdefault("random_state", 0)
 
-    def fix_country_assignment_for_hac(n):
-        from scipy.sparse import csgraph
-
-        # overwrite country of nodes that are disconnected from their country-topology
-        for country in n.buses.country.unique():
-            m = n[n.buses.country == country].copy()
-
-            _, labels = csgraph.connected_components(
-                m.adjacency_matrix(),
-                directed=False,
-            )
-
-            component = pd.Series(labels, index=m.buses.index)
-            component_sizes = component.value_counts()
-
-            if len(component_sizes) > 1:
-                disconnected_bus = component[component == component_sizes.index[-1]].index[0]
-
-                neighbor_bus = n.lines.query(
-                    "bus0 == @disconnected_bus or bus1 == @disconnected_bus",
-                ).iloc[0][["bus0", "bus1"]]
-                new_country = next(
-                    iter(set(n.buses.loc[neighbor_bus].country) - {country}),
-                )
-
-                logger.info(
-                    f"overwriting country `{country}` of bus `{disconnected_bus}` "
-                    f"to new country `{new_country}`, because it is disconnected "
-                    "from its initial inter-country transmission grid.",
-                )
-                n.buses.at[disconnected_bus, "country"] = new_country
-        return n
-
     if algorithm == "hac":
-        feature = get_feature_for_hac(n, buses_i=n.buses.index, feature=feature)
-        n = fix_country_assignment_for_hac(n)
-
-    if (algorithm != "hac") and (feature is not None):
-        logger.warning(
-            f"Keyword argument feature is only valid for algorithm `hac`. Given feature `{feature}` will be ignored.",
+        raise ValueError(
+            "HAC clustering was removed from pypsa-usa. Use algorithm='kmeans' or 'modularity'.",
         )
 
     n.determine_network_topology()
@@ -292,13 +213,6 @@ def busmap_for_n_clusters(
                 buses_i=x.index,
                 **algorithm_kwds,
             )
-        elif algorithm == "hac":
-            return prefix + busmap_by_hac(
-                n,
-                n_clusters_per_region[x.name],
-                buses_i=x.index,
-                feature=feature.loc[x.index],
-            )
         elif algorithm == "modularity":
             return prefix + busmap_by_greedy_modularity(
                 n,
@@ -307,7 +221,7 @@ def busmap_for_n_clusters(
             )
         else:
             raise ValueError(
-                f"`algorithm` must be one of 'kmeans' or 'hac'. Is {algorithm}.",
+                f"`algorithm` must be one of 'kmeans' or 'modularity'. Is {algorithm}.",
             )
 
     return (
@@ -326,8 +240,7 @@ def clustering_for_n_clusters(
     line_length_factor=1.25,
     aggregation_strategies=dict(),
     solver_name="cbc",
-    algorithm="hac",
-    feature=None,
+    algorithm="kmeans",
     focus_weights=None,
     weighting_strategy=None,
 ):
@@ -338,7 +251,6 @@ def clustering_for_n_clusters(
             solver_name,
             focus_weights,
             algorithm,
-            feature,
             weighting_strategy,
         )
         # plot_busmap(n, busmap, 'busmap.png')
@@ -1064,7 +976,6 @@ if __name__ == "__main__":
             params.aggregation_strategies,
             solver_name,
             params.cluster_network["algorithm"],
-            params.cluster_network["feature"],
             params.focus_weights,
             weighting_strategy=params.cluster_network.get("weighting_strategy", None),
         )

--- a/workflow/scripts/cluster_simpl.py
+++ b/workflow/scripts/cluster_simpl.py
@@ -1,0 +1,86 @@
+# BY PyPSA-USA Authors
+"""Optional k-means clustering of the substation-level network to ``{simpl}`` clusters.
+
+Second stage of the topology-aggregation pipeline. Consumes the substation-level
+network produced by :mod:`aggregate_to_substations` and either:
+
+- When ``{simpl}`` is empty: pass-through the substation-level network and regions.
+- When ``{simpl}=N``: k-means cluster to N buses using static demand / generation
+  weighting, then dissolve the substation Voronoi cells accordingly.
+
+This script preserves the behavior of the former second half of
+``simplify_network.py`` for the k-means / modularity algorithms. HAC is no
+longer supported; ``cluster_network.busmap_for_n_clusters`` will raise if
+selected.
+"""
+
+import logging
+
+import geopandas as gpd
+import pypsa
+from _helpers import configure_logging, update_p_nom_max
+from cluster_network import cluster_regions, clustering_for_n_clusters
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "cluster_simpl",
+            interconnect="texas",
+            simpl="50",
+        )
+    configure_logging(snakemake)
+    params = snakemake.params
+    solver_name = snakemake.config["solving"]["solver"]["name"]
+
+    n = pypsa.Network(snakemake.input.network)
+
+    if snakemake.wildcards.simpl:
+        n.set_investment_periods(periods=snakemake.params.planning_horizons)
+
+        # Drop timeseries before clustering — preserves the historical
+        # simplify_network behavior; k-means and modularity use static weights
+        # only.
+        n.loads_t.p = n.loads_t.p.iloc[:, 0:0]
+        n.loads_t.q = n.loads_t.q.iloc[:, 0:0]
+        for attr in [
+            "p",
+            "q",
+            "state_of_charge",
+            "mu_state_of_charge_set",
+            "mu_energy_balance",
+            "mu_lower",
+            "mu_upper",
+            "spill",
+            "p_dispatch",
+            "p_store",
+        ]:
+            n.storage_units_t[attr] = n.storage_units_t[attr].iloc[:, 0:0]
+
+        # Patch for pypsa io clustering bug with build_years for new gens
+        n.generators.build_year += 0.001
+
+        clustering = clustering_for_n_clusters(
+            n,
+            int(snakemake.wildcards.simpl),
+            focus_weights=params.focus_weights,
+            solver_name=solver_name,
+            algorithm=params.simplify_network["algorithm"],
+            aggregation_strategies=params.aggregation_strategies,
+            weighting_strategy=params.simplify_network.get("weighting_strategy", None),
+        )
+        n = clustering.network
+
+        cluster_regions((clustering.busmap,), snakemake.input, snakemake.output)
+    else:
+        for which in ("regions_onshore", "regions_offshore"):
+            regions = gpd.read_file(getattr(snakemake.input, which))
+            regions.to_file(getattr(snakemake.output, which))
+
+    update_p_nom_max(n)
+
+    n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
## Phase 1 Summary

First of three PRs in the **simplify-early refactor** (full multi-phase plan embedded below). Splits the existing `simplify_network` rule into two rules with **no behavior change** for the default kmeans algorithm. Sets up Phase 2, which is where the actual memory reduction lives.

### What changed

- **`rule aggregate_to_substations`** (new) — pure-topology aggregation to substations:
  - `convert_to_voltage_level(n, 230)`, `remove_transformers`, busmap by `sub_id`
  - Reads `elec_base_network_l_pp.pkl`; writes `elec_b.nc` + `busmap_b.csv`
- **`rule cluster_simpl`** (new) — optional kmeans / modularity reduction to `{simpl}` clusters:
  - Reads `elec_b.nc`; writes `elec_s{simpl}.nc` + simpl regions
  - Output shape matches the former `simplify_network` rule so downstream consumers (`cluster_network` etc.) are untouched
- **HAC dropped.** `cluster_network` now raises `ValueError` if `algorithm='hac'`. Imports and helper functions (`busmap_by_hac`, `get_feature_for_hac`, `fix_country_assignment_for_hac`) removed.
- **Dead config knobs removed.** `to_substations` (never read in code) and `feature` (HAC-only) deleted from `config.default.yaml` and `config.tutorial.yaml`. Doc table updated.
- **`workflow/scripts/simplify_network.py` deleted** (renamed in git's eyes to `aggregate_to_substations.py`).

### Why kmeans = no behavior change

`simplify_network.py` had three stages: voltage normalize / transformer removal / sub_id aggregation, then a timeseries-deletion (lines 268-283 in master), then a kmeans clustering. All three stages now run in the same order across two new rules:

| Old (single rule) | New (two rules) |
| --- | --- |
| `convert_to_voltage_level + remove_transformers + aggregate_to_substations` (inside `simplify_network.py`) | `aggregate_to_substations` rule |
| timeseries deletion + `clustering_for_n_clusters` (kmeans) | `cluster_simpl` rule |

The pickle hand-off (`elec_b.nc`) is a netcdf round-trip that PyPSA already supports for the in-memory state at this point.

### Validation done in this PR

- `python -c "import ast; ast.parse(...)"` on all touched scripts: clean.
- `snakemake -n --configfile repo_data/config/config.default.yaml --until=cluster_simpl` resolves the expected chain on the Western interconnect default config:

  ```
  build_base_network -> add_demand -> add_electricity -> aggregate_to_substations -> cluster_simpl -> cluster_network
  ```

- `pre-commit run --files ...` passes (ruff, snakefmt, blackdoc, etc.).

### Test plan (to run before merge)

- [ ] Run `snakemake --until=cluster_network` end-to-end on Texas with `simpl=20, clusters=10`; compare `elec_s20.nc` bus/line counts and per-bus capacities against master baseline (expect numerical match).
- [ ] Inspect `busmap_b.csv` to confirm the bus-to-substation mapping looks correct.
- [ ] Run with `algorithm: modularity` to confirm the non-HAC path still works.

---

# Full Multi-Phase Plan (for posterity)

> Source: `.claude/plans/okay-great-i-humble-pond.md` (planning artifact from the design session that produced this PR).

## Context

The pypsa-usa Snakemake DAG today builds substation-level renewable profiles, demand timeseries, and powerplant assignments (~750 buses for Western, ~3000 for CONUS) only to throw the timeseries away inside `simplify_network.py` lines 268-283 before clustering down to ~50-200 buses. Memory pressure peaks in `build_renewable_profiles`, `build_*_demand`, and `add_electricity` — all three operate at substation granularity × 8760 hours × N planning_horizons × multiple technologies. The work is wasted: the substation-level outputs are aggregated to `{simpl}` clusters in `simplify_network`, then further reduced in `cluster_network`.

**Goal**: move the topology-aggregation and `{simpl}` kmeans clustering to run **before** the heavy per-bus rules, so RE profiles, demand, and the assembled network are only ever built at `{simpl}` granularity (~10x memory reduction at the bottleneck steps).

## Decisions Locked In

1. **Drop HAC algorithm entirely.** Remove HAC from both `simplify_network` and `cluster_network` algorithm options. Default `kmeans` stays; `modularity` stays.
2. **Use `n.buses.Pd` directly** as the static kmeans weight at the early simpl step (no new pre-aggregation pass for annual demand).
3. **Phased rollout**: three PRs. Refactor → repoint → validate.

## Current State Diagnosis

1. `workflow/scripts/build_bus_regions.py:99-126` already operates at substation granularity (keyed by `sub_id`), not raw bus. Bus regions are substation Voronoi cells. So today's RE/demand data is per-substation, not per-bus.
2. `workflow/scripts/simplify_network.py:238-260` does pure-topology aggregation (voltage normalization, transformer removal, sub_id busmap aggregation) that needs no demand or RE timeseries.
3. `workflow/scripts/simplify_network.py:268-283` **explicitly empties** `n.loads_t.p`, `n.storage_units_t.*` before the further `{simpl}` clustering — evidence that those timeseries are not needed for clustering.
4. `clustering_for_n_clusters` in `cluster_network.py:202-318` (kmeans branch) needs only bus coordinates, network topology, and static per-bus weights (`Pd` or `gen.p_nom + load.p_set.mean()`). No hourly timeseries required.
5. Default `simplify_network.algorithm: kmeans` (config.default.yaml:203); HAC is a non-default option.
6. `clustering.simplify_network.to_substations` (config.default.yaml:202) is dead code — referenced nowhere in scripts. Delete during refactor.

## Recommended Architecture

### New DAG ordering (electricity path)

```
build_base_network        -> elec_base_network.nc                      (raw, all bus levels)
build_shapes              -> *_shapes.geojson
build_bus_regions         -> regions_onshore_b.geojson                 (per-substation Voronoi)
                             regions_offshore_b.geojson

NEW: aggregate_to_subs    -> elec_b.nc                                 (substation topology, no timeseries)
                             busmap_b.csv                              (raw bus -> sub_id)

NEW: cluster_simpl        -> elec_s{simpl}.nc                          (~50-200 buses, no timeseries)
                             regions_onshore_s{simpl}.geojson
                             regions_offshore_s{simpl}.geojson
                             busmap_b_s{simpl}.csv

build_renewable_profiles  -> profile_s{simpl}_{technology}.nc          (cluster bus index)
build_*_demand            -> demand outputs keyed by cluster bus
build_powerplants         -> powerplants.csv                           (unchanged, global)
add_demand                -> elec_s{simpl}_dem.nc
add_electricity           -> elec_s{simpl}_l_pp.pkl

cluster_network           -> elec_s{simpl}_c{clusters}.nc              (final, kmeans/modularity only)

add_extra_components, prepare_network, solve_network                   (unchanged)
```

### Rules and I/O

**Rule `aggregate_to_substations` (NEW — landed in this PR)**
- input: `elec_base_network.nc`, `bus2sub.csv`, `sub.csv`, `regions_onshore_b.geojson`, `regions_offshore_b.geojson`
- output: `elec_b.nc`, `busmap_b.csv`
- script: `workflow/scripts/aggregate_to_substations.py` (extracted from `simplify_network.py:238-260` — convert_to_voltage_level, remove_transformers, aggregate_to_substations; nothing else)
- params: `aggregation_strategies`, `topological_boundaries`

**Rule `cluster_simpl` (NEW — landed in this PR)**
- input: `elec_b.nc`, `regions_onshore_b.geojson`, `regions_offshore_b.geojson`
- output: `elec_s{simpl}.nc`, `regions_onshore_s{simpl}.geojson`, `regions_offshore_s{simpl}.geojson`, `busmap_b_s{simpl}.csv`
- script: `workflow/scripts/cluster_simpl.py` (thin wrapper around `cluster_network.clustering_for_n_clusters` with `algorithm` constrained to `kmeans|modularity`, weighting using `n.buses.Pd`)
- params: `simplify_network` config block, `focus_weights`, `planning_horizons`

**Existing rules to repoint** (Phase 2):
- `build_renewable_profiles`: input `regions_onshore_s{simpl}.geojson` (was `regions_onshore.geojson`); output `profile_s{simpl}_{technology}.nc`
- `build_electrical_demand` and other demand rules: input network becomes `elec_s{simpl}.nc`
- `add_demand`: input becomes `elec_s{simpl}.nc` + demand CSVs; output `elec_s{simpl}_dem.nc`
- `add_electricity`: input `base_network` becomes `elec_s{simpl}_dem.nc`; remove the `bus2sub` indirection in `attach_wind_and_solar` (profile bus == network bus now)
- `cluster_network`: input unchanged shape but with full hourly profiles attached; enforce algorithm in `kmeans|modularity`

**Existing rule deleted (this PR)**: `simplify_network` rule and `simplify_network.py`. The substation-aggregation logic moved into `aggregate_to_substations.py`; the kmeans-clustering logic stays in `cluster_network.py` and is called by both `cluster_simpl.py` and `cluster_network`.

### Weighting change in `cluster_network.weighting_for_region` (Phase 2)

Today (cluster_network.py:57): `n.loads_t.p_set.mean().groupby(n.loads.bus).sum()` for load weight. After Phase 2, when called from `cluster_simpl` there are no loads attached. Add a parameter `static_weighting: bool` to `weighting_for_region`:
- when `True` (called from cluster_simpl): use `n.buses.Pd` for load_weight and `n.generators.p_nom.groupby(n.generators.bus).sum()` if generators exist, else zero
- when `False` (called from cluster_network, today's behavior): unchanged

## Phased Implementation Plan

### Phase 1 — Refactor with no behavior change (THIS PR)

**Goal**: Split `simplify_network.py` into `aggregate_to_substations.py` + `cluster_simpl.py`. Update `build_electricity.smk` to chain them. Keep all downstream rules pointing at `elec_base_network.nc` unchanged. Network outputs should be byte-equivalent (or numerically identical) to today for `algorithm=kmeans`.

Steps:
1. Create `workflow/scripts/aggregate_to_substations.py` from `simplify_network.py:1-260` minus the clustering and timeseries-deletion blocks.
2. Create `workflow/scripts/cluster_simpl.py` that loads `elec_b.nc`, applies `clustering_for_n_clusters` with kmeans + `Pd` weighting, exports `elec_s{simpl}.nc` and the simplified regions.
3. Add the two new rules in `workflow/rules/build_electricity.smk`. Delete the `rule simplify_network` block.
4. Delete `workflow/scripts/simplify_network.py`.
5. Remove `algorithm: hac` from `simplify_network` and `cluster_network` options in config defaults and validation. Update docs in `workflow/repo_data/config/config.default.yaml:200-210`. Delete dead `to_substations` knob (line 202).
6. Move `get_feature_for_hac` and `busmap_by_hac` from `cluster_network.py` — delete if no other callers, or leave but warn.

Milestone: regression-test against a small interconnect (Texas, default config). Run `snakemake --until cluster_network` on master and feature branch; assert network capacities, line lengths, and bus counts match within numerical tolerance.

### Phase 2 — Repoint downstream rules

**Goal**: Switch `build_renewable_profiles`, demand rules, `add_demand`, `add_electricity` to consume `elec_s{simpl}.nc` instead of substation-level data. Achieves the actual memory reduction.

Steps:
1. Update `build_renewable_profiles` rule: input regions → `regions_onshore_s{simpl}.geojson`, output filename → `profile_s{simpl}_{technology}.nc`. Propagate `{simpl}` wildcard through downstream consumers.
2. Update demand-building rules in `build_electricity.smk:392-527`: input network becomes `elec_s{simpl}.nc`. The `Pd` aggregation already happens via `bus_strategies={"Pd": "sum"}` in `cluster_network.py:351`.
3. Update `add_demand` rule (`build_electricity.smk:576-594`): input `elec_s{simpl}.nc` + demand outputs; output `elec_s{simpl}_dem.nc`.
4. Update `add_electricity` rule (`build_electricity.smk:662-739`): input `elec_s{simpl}_dem.nc`. In the script, remove the `bus2sub` join in `attach_wind_and_solar` (lines 549-654) — profile index already matches bus index. Update `match_plant_to_bus` so the same-reeds_zone first-pass filter still works against cluster buses (use `bus_strategies={"reeds_zone": "first"}` in `cluster_simpl`).
5. Update `cluster_network` rule: input shape unchanged but now receives a network with full timeseries (no longer stripped at simpl step). The existing timeseries-aware aggregation path applies. Drop HAC branch in `busmap_for_n_clusters` (cluster_network.py:241-243).
6. Verify `custom_busmap` flow: the file should now map cluster_simpl-output bus IDs → final cluster names. Document the change. Version the path: `data/{interconnect}/custom_busmap_s{simpl}_c{clusters}.csv`.

Milestone: end-to-end Texas run with `simpl=20, clusters=10`. Compare:
- peak RSS in `build_renewable_profiles` and `add_electricity` (expect 5-10x drop)
- total generation capacity per technology (match within 0.1%)
- annual demand per state (exact match)
- objective value after `solve_network` (within 1% of pre-refactor baseline)

### Phase 3 — Validate, document, deprecate

**Goal**: Production-ready. Validate on Western and CONUS, write migration notes, remove old code paths.

Steps:
1. Run full Western interconnect; verify memory and solver-equivalence targets.
2. Run CONUS interconnect; collect memory profile vs. baseline.
3. Update `docs/` model architecture page describing the new DAG.
4. Update `config.default.yaml` comments and `docs/configtables/` for any renamed options.
5. Write `CHANGELOG` entry and migration guide for users with custom busmaps or custom configs touching `simplify_network`.
6. Delete any remaining HAC code paths and dead config knobs.

Milestone: PR merged into v1-epic with green CI and a tagged baseline-comparison report in `.pr-assets/`.

## Pitfalls and Mitigations

1. **Powerplant assignment shifts.** `match_plant_to_bus` in `add_electricity.py` filters by `buses["reeds_zone"] == plants["country"]` before falling back to nearest. With ~50-200 cluster buses each spanning multiple reeds_zones, the filter behavior degrades. **Mitigation**: add `bus_strategies={"reeds_zone": "first"}` to the `cluster_simpl` aggregation so each cluster carries a representative reeds_zone. Capacity totals per zone remain preserved because plants still snap to their nearest cluster bus.
2. **Demand disaggregation coarser.** `WritePopulation` divides zonal demand among buses proportional to `Pd`. With fewer buses per zone post-cluster, the split is coarser. **Mitigation**: zone totals are preserved by `bus_strategies={"Pd": "sum"}`. Document the change; not a correctness issue.
3. **`Pd` quality as kmeans weight.** `Pd` comes from breakthrough_network's pre-2018 bus.csv; population-driven, not modern-demand-driven. **Mitigation**: accepted trade-off (user choice). Cluster assignments are robust to small weight differences. If quality issues emerge later, swap in Phase-3 follow-up.
4. **`custom_busmap` semantics break.** Existing files key on simplify-output buses → cluster names. Bus IDs change after the refactor. **Mitigation**: version the file path (`custom_busmap_s{simpl}_c{clusters}.csv`); add a migration note. If unused, deprecate.
5. **Investment-period handling.** Today `n.set_investment_periods` is called at `simplify_network.py:266`. **Mitigation**: move the call into `cluster_simpl.py` at the equivalent point.
6. **Empty cluster regions.** `cluster_regions` may produce empty geometries when the dissolve hits degenerate inputs. **Mitigation**: assert no empty geometries in `cluster_simpl.py` before exporting; fail fast.
7. **REEDS metadata loss.** Cluster buses inherit one representative `reeds_zone`, `county`, `balancing_area`, etc. via `bus_strategies={"first"}`. Downstream code in `apply_dynamic_pricing` (add_electricity.py:148) and REEDS calibration (cluster_network.py:1098+) consumes these. **Mitigation**: audit call sites; for any code that needs the full many-to-one mapping (e.g., summing reeds-zone-specific transmission capacity into a cluster), preserve the busmap CSV and look up through it instead of relying on the cluster's representative attribute.
8. **HAC users.** Removing HAC is a breaking change. **Mitigation**: tagged in release notes; suggest kmeans + tuned focus_weights as substitute.

## Critical Files

- `workflow/rules/build_electricity.smk` (rule wiring)
- `workflow/scripts/simplify_network.py` (split & delete — done in this PR)
- `workflow/scripts/cluster_network.py` (drop HAC, parameterize weighting in Phase 2)
- `workflow/scripts/add_electricity.py` (drop `bus2sub` join, fix `match_plant_to_bus` filter — Phase 2)
- `workflow/scripts/build_demand.py` (input network swap — Phase 2)
- `workflow/scripts/build_renewable_profiles.py` (input regions swap, output filename — Phase 2)
- `workflow/scripts/build_bus_regions.py` (no change in Phase 1-2; rename outputs to `_b` suffix in Phase 3)
- `workflow/repo_data/config/config.default.yaml` (drop `to_substations`, `hac` algorithm options — done in this PR)
- `docs/` (model architecture description — Phase 3)

### Files created in this PR

- `workflow/scripts/aggregate_to_substations.py`
- `workflow/scripts/cluster_simpl.py`

## Verification

### Phase 1 (refactor, no behavior change) — this PR
- `snakemake --until cluster_network` on Texas interconnect, simpl=20, clusters=10
- Diff `elec_s20.nc` between master and refactor branch:
  - bus count, line count match exactly
  - line length, impedances, capacities match within 1e-6
  - generator p_nom per bus matches within 1e-6
- Memory profile of `aggregate_to_substations` + `cluster_simpl` combined vs. old `simplify_network`: expect roughly equal (this phase doesn't change what's loaded)

### Phase 2 (memory win)
- Same Texas run; expect peak RSS in `build_renewable_profiles` to drop from ~6-8 GB to ~1 GB. Confirm with `/usr/bin/time -v` or `psutil` instrumentation.
- Capacity totals per technology per state match within 0.1%
- Annual demand per state matches exactly (state totals are invariant under re-disaggregation)
- `solve_network` objective within 1% of baseline on Texas (kmeans cluster assignment differences cause small expected drift)

### Phase 3 (production)
- Western interconnect end-to-end with default config
- CONUS interconnect (sample one zone, full year)
- Memory profile attached to PR
- Baseline vs. new-flow objective comparison in `.pr-assets/`

## Out of Scope

- Replacing kmeans with a topology-aware clustering (e.g., spectral). Future work.
- Reintroducing HAC via a cheap RE-features pre-pass. Discarded by user decision.
- Switching to per-cluster atlite cutouts (vs. shared cutout + per-region exclusion). Future work.
- Sector-coupling rules (`build_*` for heating/transport). They consume the same network and inherit the memory win without changes; verify in Phase 3.