### PR TITLE
Phase 2: move simplify/cluster_simpl ahead of demand+RE; deliver the memory win

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -186,9 +186,10 @@ rule build_renewable_profiles:
         cec_solar="repo_data/geospatial/CEC_GIS/CEC_Solar_BaseScreen_epsg3310.tif",
         boem_osw="repo_data/geospatial/boem_osw_planning_areas.tif",
         regions=lambda w: (
-            RESOURCES + "{interconnect}/Geospatial/regions_onshore.geojson"
+            RESOURCES + "{interconnect}/Geospatial/regions_onshore_s{simpl}.geojson"
             if w.technology in ("onwind", "solar")
-            else RESOURCES + "{interconnect}/Geospatial/regions_offshore.geojson"
+            else RESOURCES
+            + "{interconnect}/Geospatial/regions_offshore_s{simpl}.geojson"
         ),
         nrel_avail=lambda w: (
             DATA
@@ -247,21 +248,23 @@ rule build_renewable_profiles:
         ),
     output:
         profile=(
-            RESOURCES + "{interconnect}/{planning_horizon}/profile_{technology}.nc"
+            RESOURCES
+            + "{interconnect}/{planning_horizon}/profile_{technology}_s{simpl}.nc"
             if godeeep_planning_horizon
-            else RESOURCES + "{interconnect}/profile_{technology}.nc"
+            else RESOURCES + "{interconnect}/profile_{technology}_s{simpl}.nc"
         ),
     log:
         LOGS
-        + "{interconnect}/build_renewable_profile_{technology}_{planning_horizon}.log"
+        + "{interconnect}/build_renewable_profile_{technology}_{planning_horizon}_s{simpl}.log"
         if godeeep_planning_horizon
-        else LOGS + "{interconnect}/build_renewable_profile_{technology}.log",
+        else LOGS + "{interconnect}/build_renewable_profile_{technology}_s{simpl}.log",
     benchmark:
         (
             BENCHMARKS
-            + "{interconnect}/build_renewable_profiles_{technology}_{planning_horizon}"
+            + "{interconnect}/build_renewable_profiles_{technology}_{planning_horizon}_s{simpl}"
             if godeeep_planning_horizon
-            else BENCHMARKS + "{interconnect}/build_renewable_profiles_{technology}"
+            else BENCHMARKS
+            + "{interconnect}/build_renewable_profiles_{technology}_s{simpl}"
         )
     threads: ATLITE_NPROCESSES
     resources:
@@ -400,15 +403,16 @@ rule build_electrical_demand:
         snapshots=config["snapshots"],
         pudl_path=config_provider("pudl_path"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand_files=demand_raw_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        elec_demand=RESOURCES + "{interconnect}/demand/{end_use}_electricity.csv",
+        elec_demand=RESOURCES
+        + "{interconnect}/demand/{end_use}_electricity_s{simpl}.csv",
     log:
-        LOGS + "{interconnect}/{end_use}_build_demand.log",
+        LOGS + "{interconnect}/{end_use}_build_demand_s{simpl}.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/{end_use}_build_demand"
+        BENCHMARKS + "{interconnect}/{end_use}_build_demand_s{simpl}"
     threads: 2
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 100000) * attempt * 2,
@@ -428,19 +432,22 @@ rule build_service_demand:
         eia_api=config_provider("api", "eia"),
         snapshots=config_provider("snapshots"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand_files=demand_raw_data,
         dissagregate_files=demand_dissagregate_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        electricity=RESOURCES + "{interconnect}/demand/{end_use}_electricity.pkl",
-        space_heat=RESOURCES + "{interconnect}/demand/{end_use}_space-heating.pkl",
-        water_heat=RESOURCES + "{interconnect}/demand/{end_use}_water-heating.pkl",
-        cool=RESOURCES + "{interconnect}/demand/{end_use}_cooling.pkl",
+        electricity=RESOURCES
+        + "{interconnect}/demand/{end_use}_electricity_s{simpl}.pkl",
+        space_heat=RESOURCES
+        + "{interconnect}/demand/{end_use}_space-heating_s{simpl}.pkl",
+        water_heat=RESOURCES
+        + "{interconnect}/demand/{end_use}_water-heating_s{simpl}.pkl",
+        cool=RESOURCES + "{interconnect}/demand/{end_use}_cooling_s{simpl}.pkl",
     log:
-        LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
+        LOGS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand"
+        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}"
     threads: 2
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
@@ -458,17 +465,18 @@ rule build_industry_demand:
         snapshots=config_provider("snapshots"),
         pudl_path=config_provider("pudl_path"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand_files=demand_raw_data,
         dissagregate_files=demand_dissagregate_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        electricity=RESOURCES + "{interconnect}/demand/{end_use}_electricity.pkl",
-        heat=RESOURCES + "{interconnect}/demand/{end_use}_heating.pkl",
+        electricity=RESOURCES
+        + "{interconnect}/demand/{end_use}_electricity_s{simpl}.pkl",
+        heat=RESOURCES + "{interconnect}/demand/{end_use}_heating_s{simpl}.pkl",
     log:
-        LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
+        LOGS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand"
+        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}"
     threads: 2
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
@@ -486,19 +494,19 @@ rule build_transport_road_demand:
         eia_api=config_provider("api", "eia"),
         snapshots=config_provider("snapshots"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand_files=demand_raw_data,
         dissagregate_files=demand_dissagregate_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        light_duty=RESOURCES + "{interconnect}/demand/{end_use}_light-duty.pkl",
-        med_duty=RESOURCES + "{interconnect}/demand/{end_use}_med-duty.pkl",
-        heavy_duty=RESOURCES + "{interconnect}/demand/{end_use}_heavy-duty.pkl",
-        bus=RESOURCES + "{interconnect}/demand/{end_use}_bus.pkl",
+        light_duty=RESOURCES + "{interconnect}/demand/{end_use}_light-duty_s{simpl}.pkl",
+        med_duty=RESOURCES + "{interconnect}/demand/{end_use}_med-duty_s{simpl}.pkl",
+        heavy_duty=RESOURCES + "{interconnect}/demand/{end_use}_heavy-duty_s{simpl}.pkl",
+        bus=RESOURCES + "{interconnect}/demand/{end_use}_bus_s{simpl}.pkl",
     log:
-        LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
+        LOGS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand"
+        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand_s{simpl}"
     threads: 2
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
@@ -518,15 +526,16 @@ rule build_transport_other_demand:
         eia_api=config_provider("api", "eia"),
         snapshots=config_provider("snapshots"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand_files=demand_raw_data,
         dissagregate_files=demand_dissagregate_data,
     output:
-        RESOURCES + "{interconnect}/demand/{end_use}_{vehicle}.pkl",
+        RESOURCES + "{interconnect}/demand/{end_use}_{vehicle}_s{simpl}.pkl",
     log:
-        LOGS + "{interconnect}/demand/{end_use}_{vehicle}_build_demand.log",
+        LOGS + "{interconnect}/demand/{end_use}_{vehicle}_build_demand_s{simpl}.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/demand/{end_use}_{vehicle}_build_demand"
+        BENCHMARKS
+        +"{interconnect}/demand/{end_use}_{vehicle}_build_demand_s{simpl}"
     threads: 2
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
@@ -537,7 +546,7 @@ rule build_transport_other_demand:
 def demand_to_add(wildcards):
 
     if config["scenario"]["sector"] == "E":
-        return RESOURCES + "{interconnect}/demand/power_electricity.csv"
+        return RESOURCES + "{interconnect}/demand/power_electricity_s{simpl}.csv"
     else:
         # service demand
         services = ["residential", "commercial"]
@@ -546,27 +555,32 @@ def demand_to_add(wildcards):
         else:
             fuels = ["electricity", "cooling", "heating"]
         service_demands = [
-            RESOURCES + "{interconnect}/demand/" + service + "_" + fuel + ".pkl"
+            RESOURCES
+            + "{interconnect}/demand/"
+            + service
+            + "_"
+            + fuel
+            + "_s{simpl}.pkl"
             for service in services
             for fuel in fuels
         ]
         # industrial demand
         fuels = ["electricity", "heating"]
         industrial_demands = [
-            RESOURCES + "{interconnect}/demand/industry_" + fuel + ".pkl"
+            RESOURCES + "{interconnect}/demand/industry_" + fuel + "_s{simpl}.pkl"
             for fuel in fuels
         ]
         # road transport demands
         vehicles = ["light-duty", "med-duty", "heavy-duty", "bus"]
         road_demand = [
-            RESOURCES + "{interconnect}/demand/transport_" + vehicle + ".pkl"
+            RESOURCES + "{interconnect}/demand/transport_" + vehicle + "_s{simpl}.pkl"
             for vehicle in vehicles
         ]
 
         # other transport demands
         vehicles = ["boat-shipping", "rail-shipping", "rail-passenger", "air"]
         non_road_demand = [
-            RESOURCES + "{interconnect}/demand/transport_" + vehicle + ".pkl"
+            RESOURCES + "{interconnect}/demand/transport_" + vehicle + "_s{simpl}.pkl"
             for vehicle in vehicles
         ]
 
@@ -579,14 +593,14 @@ rule add_demand:
         planning_horizons=config_provider("scenario", "planning_horizons"),
         snapshots=config_provider("snapshots"),
     input:
-        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         demand=demand_to_add,
     output:
-        network=RESOURCES + "{interconnect}/elec_base_network_dem.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}_dem.nc",
     log:
-        LOGS + "{interconnect}/add_demand.log",
+        LOGS + "{interconnect}/elec_s{simpl}_add_demand.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/add_demand"
+        BENCHMARKS + "{interconnect}/elec_s{simpl}_add_demand"
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
         walltime=config_provider("walltime", "add_demand", default="00:50:00"),
@@ -676,7 +690,7 @@ rule add_electricity:
             {
                 # For GODEEEP future scenarios: pass all horizon-specific profiles
                 f"profile_{tech}_{horizon}": RESOURCES
-                + f"{{interconnect}}/{horizon}/profile_{tech}.nc"
+                + f"{{interconnect}}/{horizon}/profile_{tech}_s{{simpl}}.nc"
                 for tech in config["electricity"]["renewable_carriers"]
                 if tech != "hydro"
                 for horizon in config["scenario"]["planning_horizons"]
@@ -684,7 +698,9 @@ rule add_electricity:
             if godeeep_planning_horizon
             else {
                 # For historical or AtLite: pass single profile
-                f"profile_{tech}": RESOURCES + "{interconnect}" + f"/profile_{tech}.nc"
+                f"profile_{tech}": RESOURCES
+                + "{interconnect}"
+                + f"/profile_{tech}_s{{simpl}}.nc"
                 for tech in config["electricity"]["renewable_carriers"]
                 if tech != "hydro"
             }
@@ -700,15 +716,16 @@ rule add_electricity:
             f"gen_cost_mult_{Path(x).stem}": f"repo_data/locational_multipliers/{Path(x).name}"
             for x in Path("repo_data/locational_multipliers/").glob("*")
         },
-        base_network=RESOURCES + "{interconnect}/elec_base_network_dem.nc",
+        base_network=RESOURCES + "{interconnect}/elec_s{simpl}_dem.nc",
         tech_costs=RESOURCES
         + f"costs/costs_{config['scenario']['planning_horizons'][0]}.csv",
         # attach first horizon costs
         all_reeds_shapes="repo_data/geospatial/Reeds_Shapes/rb_and_ba_areas.shp",
         reeds_memberships="repo_data/ReEDS_Constraints/membership.csv",
-        regions_onshore=RESOURCES + "{interconnect}/Geospatial/regions_onshore.geojson",
+        regions_onshore=RESOURCES
+        + "{interconnect}/Geospatial/regions_onshore_s{simpl}.geojson",
         regions_offshore=RESOURCES
-        + "{interconnect}/Geospatial/regions_offshore.geojson",
+        + "{interconnect}/Geospatial/regions_offshore_s{simpl}.geojson",
         reeds_shapes=RESOURCES + "{interconnect}/Geospatial/reeds_shapes.geojson",
         powerplants="resources/powerplants.csv",
         plants_breakthrough=DATA + "breakthrough_network/base_grid/plant.csv",
@@ -726,11 +743,11 @@ rule add_electricity:
             else []
         ),
     output:
-        RESOURCES + "{interconnect}/elec_base_network_l_pp.pkl",
+        RESOURCES + "{interconnect}/elec_s{simpl}_l_pp.pkl",
     log:
-        LOGS + "{interconnect}/add_electricity.log",
+        LOGS + "{interconnect}/elec_s{simpl}_add_electricity.log",
     benchmark:
-        BENCHMARKS + "{interconnect}/add_electricity"
+        BENCHMARKS + "{interconnect}/elec_s{simpl}_add_electricity"
     threads: 1
     resources:
         mem_mb=lambda wildcards, input, attempt: (input.size // 400000) * attempt * 2,
@@ -749,7 +766,7 @@ rule aggregate_to_substations:
     input:
         bus2sub=RESOURCES + "{interconnect}/bus2sub.csv",
         sub=RESOURCES + "{interconnect}/sub.csv",
-        network=RESOURCES + "{interconnect}/elec_base_network_l_pp.pkl",
+        network=RESOURCES + "{interconnect}/elec_base_network.nc",
     output:
         network=RESOURCES + "{interconnect}/elec_b.nc",
         busmap=RESOURCES + "{interconnect}/busmap_b.csv",
@@ -810,7 +827,7 @@ rule cluster_network:
         topology_aggregation=config_provider("model_topology", "aggregate"),
         s_max_pu=config_provider("lines", "s_max_pu", default=0.7),
     input:
-        network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
+        network=RESOURCES + "{interconnect}/elec_s{simpl}_l_pp.pkl",
         regions_onshore=RESOURCES
         + "{interconnect}/Geospatial/regions_onshore_s{simpl}.geojson",
         regions_offshore=RESOURCES

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -546,12 +546,8 @@ def attach_wind_and_solar(
 
         capital_cost = costs.at[car, "annualized_capex_fom"]
 
-        bus2sub = (
-            pd.read_csv(input_profiles.bus2sub, dtype=str)
-            .drop("interconnect", axis=1)
-            .rename(columns={"Bus": "bus_id"})
-            .drop_duplicates(subset="sub_id")
-        )
+        # Profile bus index already matches the network bus index after
+        # cluster_simpl runs upstream — both are keyed by simpl-cluster bus.
 
         # For GODEEEP future scenarios, load horizon-specific profiles
         if godeeep_future:
@@ -572,40 +568,28 @@ def attach_wind_and_solar(
                     if ds.indexes["bus"].empty:
                         continue
 
-                    # Get bus list
+                    # Get bus list (profile bus = network bus, both at cluster level)
                     if bus_list is None:
-                        bus_list = ds.bus.to_dataframe("sub_id").merge(bus2sub).bus_id.astype(str).values
+                        bus_list = ds.bus.values.astype(str)
 
-                        # Get p_nom_max and weight
                         p_nom_max_bus = (
                             ds["p_nom_max"]
-                            .to_dataframe()
-                            .merge(bus2sub[["bus_id", "sub_id"]], left_on="bus", right_on="sub_id")
-                            .set_index("bus_id")
-                            .p_nom_max
+                            .to_pandas()
+                            .rename(
+                                index=lambda b: str(b),
+                            )
                         )
                         weight_bus = (
                             ds["weight"]
-                            .to_dataframe()
-                            .merge(bus2sub[["bus_id", "sub_id"]], left_on="bus", right_on="sub_id")
-                            .set_index("bus_id")
-                            .weight
+                            .to_pandas()
+                            .rename(
+                                index=lambda b: str(b),
+                            )
                         )
 
-                    # Get profile for this horizon
-                    horizon_profile = (
-                        ds["profile"]
-                        .transpose("time", "bus")
-                        .to_pandas()
-                        .T.merge(
-                            bus2sub[["bus_id", "sub_id"]],
-                            left_on="bus",
-                            right_on="sub_id",
-                        )
-                        .set_index("bus_id")
-                        .drop(columns="sub_id")
-                        .T
-                    )
+                    # Get profile for this horizon — index already at bus level
+                    horizon_profile = ds["profile"].transpose("time", "bus").to_pandas()
+                    horizon_profile.columns = horizon_profile.columns.astype(str)
 
                     # Update timestamps to match the horizon year
                     horizon_profile.index = horizon_profile.index.map(lambda x: x.replace(year=int(horizon)))
@@ -624,34 +608,23 @@ def attach_wind_and_solar(
                 if ds.indexes["bus"].empty:
                     continue
 
-                bus_list = ds.bus.to_dataframe("sub_id").merge(bus2sub).bus_id.astype(str).values
+                bus_list = ds.bus.values.astype(str)
                 p_nom_max_bus = (
                     ds["p_nom_max"]
-                    .to_dataframe()
-                    .merge(bus2sub[["bus_id", "sub_id"]], left_on="bus", right_on="sub_id")
-                    .set_index("bus_id")
-                    .p_nom_max
+                    .to_pandas()
+                    .rename(
+                        index=lambda b: str(b),
+                    )
                 )
                 weight_bus = (
                     ds["weight"]
-                    .to_dataframe()
-                    .merge(bus2sub[["bus_id", "sub_id"]], left_on="bus", right_on="sub_id")
-                    .set_index("bus_id")
-                    .weight
-                )
-                bus_profiles = (
-                    ds["profile"]
-                    .transpose("time", "bus")
                     .to_pandas()
-                    .T.merge(
-                        bus2sub[["bus_id", "sub_id"]],
-                        left_on="bus",
-                        right_on="sub_id",
+                    .rename(
+                        index=lambda b: str(b),
                     )
-                    .set_index("bus_id")
-                    .drop(columns="sub_id")
-                    .T
                 )
+                bus_profiles = ds["profile"].transpose("time", "bus").to_pandas()
+                bus_profiles.columns = bus_profiles.columns.astype(str)
                 # Broadcast single profile across all horizons
                 bus_profiles = broadcast_investment_horizons_index(n, bus_profiles)
 

--- a/workflow/scripts/aggregate_to_substations.py
+++ b/workflow/scripts/aggregate_to_substations.py
@@ -1,9 +1,9 @@
 # BY PyPSA-USA Authors
-"""Aggregates the full nodal network to substation level and normalizes to one voltage.
+"""Aggregates the bare topology network to substation level and normalizes to one voltage.
 
-First stage of the topology-aggregation pipeline (formerly the first half of
-``simplify_network.py``). Consumes the full nodal network produced by
-``add_electricity`` and reduces it to one bus per substation via:
+First stage of the topology-aggregation pipeline. Consumes ``elec_base_network.nc``
+(buses, lines, transformers only — no generators, loads, or storage attached) and
+reduces it to one bus per substation via:
 
 1. Converting line parameters to a single voltage base (230 kV).
 2. Removing transformers, collapsing voltage layers into a single bus per
@@ -11,12 +11,12 @@ First stage of the topology-aggregation pipeline (formerly the first half of
 3. Aggregating buses by ``sub_id``.
 
 The downstream ``cluster_simpl`` rule may then optionally apply k-means
-clustering to ``{simpl}`` clusters.
+clustering to ``{simpl}`` clusters before any per-bus heavy data (renewable
+profiles, demand) is built.
 """
 
 import logging
 
-import dill as pickle
 import numpy as np
 import pandas as pd
 import pypsa
@@ -209,11 +209,7 @@ if __name__ == "__main__":
 
     topological_boundaries = snakemake.params.topological_boundaries
 
-    n = pickle.load(open(snakemake.input.network, "rb"))
-
-    n.generators = n.generators.drop(
-        columns=["ba_eia"],
-    )  # temp columns added in build_powerplants; drop for downstream
+    n = pypsa.Network(snakemake.input.network)
 
     n = convert_to_voltage_level(n, 230)
     n, trafo_map = remove_transformers(n)

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -802,7 +802,13 @@ if __name__ == "__main__":
     params = snakemake.params
     solver_name = snakemake.config["solving"]["solver"]["name"]
 
-    n = pypsa.Network(snakemake.input.network)
+    if str(snakemake.input.network).endswith(".pkl"):
+        import dill as pickle
+
+        with open(snakemake.input.network, "rb") as fh:
+            n = pickle.load(fh)
+    else:
+        n = pypsa.Network(snakemake.input.network)
 
     n.set_investment_periods(
         periods=snakemake.params.planning_horizons,

--- a/workflow/scripts/cluster_simpl.py
+++ b/workflow/scripts/cluster_simpl.py
@@ -2,16 +2,21 @@
 """Optional k-means clustering of the substation-level network to ``{simpl}`` clusters.
 
 Second stage of the topology-aggregation pipeline. Consumes the substation-level
-network produced by :mod:`aggregate_to_substations` and either:
+topology produced by :mod:`aggregate_to_substations` (buses, lines, links only —
+no loads, generators, or storage attached) and either:
 
 - When ``{simpl}`` is empty: pass-through the substation-level network and regions.
-- When ``{simpl}=N``: k-means cluster to N buses using static demand / generation
-  weighting, then dissolve the substation Voronoi cells accordingly.
+- When ``{simpl}=N``: k-means cluster to N buses using ``n.buses.Pd`` as the static
+  per-bus weight (i.e. ``weighting_strategy=population``), then dissolve the
+  substation Voronoi cells accordingly.
 
-This script preserves the behavior of the former second half of
-``simplify_network.py`` for the k-means / modularity algorithms. HAC is no
-longer supported; ``cluster_network.busmap_for_n_clusters`` will raise if
-selected.
+Because the input network has no time-varying data attached, this script always
+uses the ``population`` weighting branch regardless of the configured
+``simplify_network.weighting_strategy``. Demand-capacity weighting requires loads
+to be attached, which only happens at the downstream ``cluster_network`` step.
+
+HAC clustering is no longer supported; ``cluster_network.busmap_for_n_clusters``
+will raise if selected.
 """
 
 import logging
@@ -40,29 +45,17 @@ if __name__ == "__main__":
     n = pypsa.Network(snakemake.input.network)
 
     if snakemake.wildcards.simpl:
-        n.set_investment_periods(periods=snakemake.params.planning_horizons)
-
-        # Drop timeseries before clustering — preserves the historical
-        # simplify_network behavior; k-means and modularity use static weights
-        # only.
-        n.loads_t.p = n.loads_t.p.iloc[:, 0:0]
-        n.loads_t.q = n.loads_t.q.iloc[:, 0:0]
-        for attr in [
-            "p",
-            "q",
-            "state_of_charge",
-            "mu_state_of_charge_set",
-            "mu_energy_balance",
-            "mu_lower",
-            "mu_upper",
-            "spill",
-            "p_dispatch",
-            "p_store",
-        ]:
-            n.storage_units_t[attr] = n.storage_units_t[attr].iloc[:, 0:0]
-
-        # Patch for pypsa io clustering bug with build_years for new gens
-        n.generators.build_year += 0.001
+        configured_strategy = params.simplify_network.get(
+            "weighting_strategy",
+            "population",
+        )
+        if configured_strategy != "population":
+            logger.info(
+                "cluster_simpl runs before loads/generators are attached; using "
+                "weighting_strategy='population' (n.buses.Pd) regardless of "
+                "configured '%s'.",
+                configured_strategy,
+            )
 
         clustering = clustering_for_n_clusters(
             n,
@@ -71,7 +64,7 @@ if __name__ == "__main__":
             solver_name=solver_name,
             algorithm=params.simplify_network["algorithm"],
             aggregation_strategies=params.aggregation_strategies,
-            weighting_strategy=params.simplify_network.get("weighting_strategy", None),
+            weighting_strategy="population",
         )
         n = clustering.network
 


### PR DESCRIPTION
## Summary

Phase 2 of the simplify-early refactor (plan in PR #8). Stacks on top of Phase 1 (PR #8) — **set that PR's base as merge target before merging this one**. This PR delivers the actual memory reduction: renewable profiles, demand timeseries, and the assembled network are now only ever built at the ``{simpl}`` cluster granularity (~50-200 buses) instead of substation granularity (~750-3000 buses).

## DAG reordering

```
build_base_network
 -> build_bus_regions                                    # substation Voronoi (unchanged)
 -> aggregate_to_substations  (in:  elec_base_network.nc)
                              (out: elec_b.nc)           # NEW: topology only, no loads/gens
 -> cluster_simpl             (in:  elec_b.nc)
                              (out: elec_s{simpl}.nc,
                                    regions_*_s{simpl}.geojson)
 -> build_renewable_profiles  (in:  regions_*_s{simpl}.geojson)
                              (out: profile_{tech}_s{simpl}.nc)
 -> build_*_demand            (in:  elec_s{simpl}.nc)
                              (out: demand/*_s{simpl}.csv|pkl)
 -> add_demand                (out: elec_s{simpl}_dem.nc)
 -> add_electricity           (out: elec_s{simpl}_l_pp.pkl)
 -> cluster_network           (in:  elec_s{simpl}_l_pp.pkl)
```

## Notable script changes

- **`aggregate_to_substations.py`** reads `elec_base_network.nc` directly (was: dill-loaded `elec_base_network_l_pp.pkl` from `add_electricity`). No generators/loads to aggregate yet, so this is pure topology work.
- **`cluster_simpl.py`** input has no `loads_t` / `generators_t`, so the timeseries-deletion block and `set_investment_periods` call are gone. Forces `weighting_strategy='population'` (uses `n.buses.Pd`) regardless of config, with an info log if the user configured `demand-capacity`.
- **`cluster_network.py`** input is now an `add_electricity` pickle. Loads via `dill` when the input ends in `.pkl`, otherwise falls back to `pypsa.Network()`.
- **`add_electricity.attach_wind_and_solar`** drops the `bus2sub` merge that fanned substation-level profiles to per-bus generators. After Phase 2 the profile bus index already equals the network bus index (both at simpl-cluster level).

## Known limitations (deferred to Phase 3)

1. **EGS path** in `add_electricity.attach_egs` still uses `bus2sub.csv` to expand precomputed substation-level data to per-bus generators. The mapped `bus_id`s no longer exist in the cluster-level network. EGS is **not** in the default `extendable_carriers` list, so default runs are unaffected; EGS users will need a follow-up that maps EGS substations through `busmap_b.csv`.
2. **Custom busmap** in `cluster_network` now expects `cluster_simpl`-output bus IDs (not substation IDs). Migration note pending.
3. **bus_strategies** for `reeds_zone`, `county`, `balancing_area` are not explicitly set during cluster_simpl, so cluster buses inherit pypsa's default for those columns. If downstream code (e.g. `match_plant_to_bus`'s reeds_zone filter) breaks during smoke test, add explicit `'first'` strategies.

## Validation in this PR

- `snakemake -n --configfile repo_data/config/config.default.yaml --until=cluster_network` resolves the new DAG (21 jobs total; `aggregate_to_substations` and `cluster_simpl` now precede `build_renewable_profiles` / demand / `add_electricity`).
- All touched scripts pass `python -c ast.parse`.
- Pre-commit clean (ruff, snakefmt, blackdoc).

## Test plan (to run before merge)

- [ ] End-to-end Texas run with `simpl=20, clusters=10`. Compare against pre-refactor baseline:
  - Peak RSS in `build_renewable_profiles` and `add_electricity`: expect **5-10x drop**.
  - Total generation capacity per technology: match within 0.1%.
  - Annual demand per state: exact match (state totals are invariant under re-disaggregation).
  - `solve_network` objective: within 1% of baseline (kmeans cluster-assignment differences cause small expected drift).
- [ ] Spot-check `regions_onshore_s20.geojson` — confirm the dissolved cluster regions look sensible.
- [ ] Confirm `match_plant_to_bus` assigns all plants (none dropped) with cluster-level `reeds_zone` filter.
- [ ] If user runs with EGS: expect failure — needs Phase 3 follow-up. Default config (no EGS) should work.

## Merge order

Merge **PR #8 (Phase 1) first**, then rebase this PR onto `v1-epic`. The current base is `claude/simplify-refactor-phase1` so the PR shows only Phase 2's diff.