### PR TITLE
Remove unused config keys and unused snakemake rule params

### DIFF
--- a/docs/source/configtables/plotting.csv
+++ b/docs/source/configtables/plotting.csv
@@ -1,10 +1,5 @@
 ,Unit,Values,Description
 map,,,
 -- boundaries,°,"[x1,x2,y1,y2]",Boundaries of the map plots in degrees latitude (y) and longitude (x)
-costs_max,bn $o,float,Upper y-axis limit in cost bar plots.
-costs_threshold,bn $o,float,Threshold below which technologies will not be shown in cost bar plots.
-energy_max,TWh,float,Upper y-axis limit in energy bar plots.
-energy_min,TWh,float,Lower y-axis limit in energy bar plots.
-energy_threshold,TWh,float,Threshold below which technologies will not be shown in energy bar plots.
 tech_colors,--,carrier -> HEX colour code,Mapping from network `carrier` to a colour ([HEX colour code](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet)).
 nice_names,--,str -> str,Mapping from network `carrier` to a more readable name.

--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -77,18 +77,9 @@ renewable:
   hydro:
     cutout: era5
     carriers: [ror, PHS, hydro]
-    PHS_max_hours: 6
     resource:
       method: hydro
-      hydrobasins: resources/hybas_na_lev06_v1c.shp
-      flowspeed: 1.0  # m/s
-    hydro_max_hours: "energy_capacity_totals_by_country"  # not active
-    clip_min_inflow: 1.0
     extendable: true
-    normalization:
-      method: hydro_capacities
-      year: 2013
-    multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
 
 
 # docs :
@@ -104,7 +95,6 @@ godeeep_wind_height: "_100m"          # raw GODEEEP wind-CF hub height (e.g. "_1
 
 # docs :
 atlite:
-  default_cutout: era5_2019
   nprocesses: 8
   show_progress: false # false saves time
   cutouts:
@@ -144,20 +134,6 @@ lines:
     500.: "Al/St 560/50 4-bundle 750.0"
     765.: "Al/St 560/50 4-bundle 750.0"
  
-
-# docs :
-electricity:
-  prm:
-    MISO: 0.183
-    NPCC_NE: 0.135
-    NPCC_NY: 0.15
-    PJM: 0.146
-    SERC: 0.15
-    SPP: 0.16
-    ERCOT: 0.1375
-    WECC_CA: 0.182
-    WECC_NWPP: 0.1435
-    WECC_SRSG: 0.1155
 
 offshore_shape:
   use: eez #options are ca_osw, eez

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -23,7 +23,6 @@ foresight:  'perfect' # myopic, perfect
 model_topology:
   transmission_network: 'reeds' # [reeds, tamu]
   topological_boundaries: 'reeds_zone' # [county, reeds_zone, state]
-  interface_transmission_limits: false
   include: # mixed zone types not supported
     # reeds_zone: []
     # reeds_state: ['CA']
@@ -308,7 +307,6 @@ solving:
     cbc-default: {} # Used in CI
     glpk-default: {} # Used in CI
 
-  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
   walltime: "12:00:00"
 
 walltime:

--- a/workflow/repo_data/config/config.plotting.yaml
+++ b/workflow/repo_data/config/config.plotting.yaml
@@ -1,11 +1,4 @@
 plotting:
-  costs_max: 800
-  costs_threshold: 1
-
-  energy_max: 15000.
-  energy_min: -10000.
-  energy_threshold: 50.
-
   tech_colors:
     "onwind": "#235ebc"
     "wind": "#235ebc"

--- a/workflow/repo_data/config/config.tutorial.yaml
+++ b/workflow/repo_data/config/config.tutorial.yaml
@@ -136,7 +136,6 @@ costs:
 sector:
   co2_sequestration_potential: 0
   natural_gas:
-    allow_imports_exports: true # false to be implemented
     cyclic_storage: false
   heating:
     heat_pump_sink_T: 55.

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -73,7 +73,6 @@ rule build_bus_regions:
         topological_boundaries=config_provider(
             "model_topology", "topological_boundaries"
         ),
-        focus_weights=config_provider("focus_weights"),
     input:
         country_shapes=RESOURCES + "{interconnect}/Geospatial/country_shapes.geojson",
         county_shapes=RESOURCES + "{interconnect}/Geospatial/county_shapes.geojson",
@@ -876,7 +875,6 @@ rule add_extra_components:
         ),
         transmission_network=config_provider("model_topology", "transmission_network"),
         costs=config_provider("costs"),
-        ucap=config_provider("ucap", default={}),
     output:
         RESOURCES + "{interconnect}/elec_s{simpl}_c{clusters}_ec.nc",
     log:
@@ -894,10 +892,8 @@ rule add_extra_components:
 rule prepare_network:
     params:
         time_resolution=config_provider("clustering", "temporal", "resolution_elec"),
-        adjustments=False,
         links=config_provider("links"),
         lines=config_provider("lines"),
-        co2base=config_provider("electricity", "co2base"),
         co2limit=config_provider("electricity", "co2limit"),
         co2limit_enable=config_provider("electricity", "co2limit_enable", default=False),
         gaslimit=config_provider("electricity", "gaslimit"),

--- a/workflow/rules/build_sector.smk
+++ b/workflow/rules/build_sector.smk
@@ -50,9 +50,6 @@ def sector_input_files(wildcards):
 
 rule add_sectors:
     params:
-        electricity=config["electricity"],
-        costs=config["costs"],
-        plotting=config["plotting"],
         snapshots=config["snapshots"],
         api=config["api"],
         sector=config["sector"],

--- a/workflow/rules/postprocess.smk
+++ b/workflow/rules/postprocess.smk
@@ -21,8 +21,6 @@ rule plot_network_maps:
         ),
     params:
         electricity=config["electricity"],
-        plotting=config["plotting"],
-        retirement=config["electricity"].get("retirement", "technical"),
     output:
         **{
             fig: RESULTS
@@ -60,7 +58,6 @@ rule plot_statistics:
         ),
     params:
         electricity=config["electricity"],
-        plotting=config["plotting"],
         retirement=config["electricity"].get("retirement", "technical"),
     output:
         **{

--- a/workflow/rules/postprocess_sector.smk
+++ b/workflow/rules/postprocess_sector.smk
@@ -44,8 +44,6 @@ rule plot_natural_gas:
     input:
         network=RESULTS
         + "{interconnect}/networks/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
-    params:
-        plotting=config["plotting"],
     output:
         **{
             fig: RESULTS

--- a/workflow/rules/solve_electricity.smk
+++ b/workflow/rules/solve_electricity.smk
@@ -19,9 +19,6 @@ rule solve_network:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config["scenario"]["planning_horizons"],
-        transmission_network=config_provider("model_topology", "transmission_network"),
-        sector_config=config_provider("sector", default={}),
     input:
         network=RESOURCES
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -2,10 +2,6 @@ rule solve_network_validation:
     params:
         solving=config["solving"],
         foresight=config["foresight"],
-        planning_horizons=config["scenario"]["planning_horizons"],
-        co2_sequestration_potential=config["sector"].get(
-            "co2_sequestration_potential", 200
-        ),
     input:
         network=RESOURCES
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",


### PR DESCRIPTION
## Summary
Dead-code cleanup audit against `v1-epic`. No behavior change — every removal was verified by greping the leaf-name across `.py`, `.smk`, and `Snakefile` files; only keys/params with zero code references were removed.

### YAML config keys removed
- **config.plotting.yaml**: `costs_max`, `costs_threshold`, `energy_max`, `energy_min`, `energy_threshold` (+ matching rows in `docs/source/configtables/plotting.csv`)
- **config.tutorial.yaml**: `sector.natural_gas.allow_imports_exports` (was commented `# false to be implemented`)
- **config.common.yaml**:
  - `renewable.hydro.*` leftover atlite-hydro keys (`PHS_max_hours`, `resource.hydrobasins`, `resource.flowspeed`, `hydro_max_hours`, `clip_min_inflow`, `normalization`, `multiplier`) — `build_renewable_profiles` rule explicitly excludes hydro via `wildcard_constraints`
  - `atlite.default_cutout`
  - `electricity.prm` (entire regional reserve-margin dict — never read; the active reserve-margin code paths use `electricity.SAFE_regional_reservemargins` / operational_reserve)
- **config.default.yaml**: `model_topology.interface_transmission_limits`, `solving.mem`

### Snakemake rule `params:` removed
Each was declared but never accessed via `snakemake.params.<name>` in the target script:
- `build_bus_regions`: `focus_weights`
- `add_extra_components`: `ucap` (script reads via `snakemake.config[\"ucap\"]` directly — code-style fix, not feature change)
- `prepare_network`: `adjustments` (hardcoded `False`), `co2base`
- `add_sectors`: `electricity`, `costs`, `plotting`
- `plot_network_maps`: `plotting`, `retirement`
- `plot_statistics`: `plotting`
- `plot_natural_gas`: `plotting`
- `solve_network`: `planning_horizons`, `transmission_network`, `sector_config`
- `solve_network_validation`: `planning_horizons`, `co2_sequestration_potential`

### Stats
58 lines deleted across 11 files. No insertions.

## Test plan
- [ ] `snakemake --dry-run` succeeds for a representative run (e.g., `western`, single planning horizon, `solve_network`)
- [ ] A full electricity-only solve completes and matches a baseline run on `v1-epic` (objective value, dispatch, capacities)
- [ ] A sector-coupled solve (`add_sectors`) runs end-to-end
- [ ] Validation pipeline (`solve_network_validation`) runs end-to-end
- [ ] `plot_network_maps`, `plot_statistics`, `plot_natural_gas` produce figures
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)