### PR TITLE
Phase 3: aggregate EGS supply curves through cluster_simpl busmap

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -733,12 +733,12 @@ rule add_electricity:
         bus2sub=RESOURCES + "{interconnect}/bus2sub.csv",
         pudl_fuel_costs=RESOURCES + "{interconnect}/pudl_fuel_costs.csv",
         specs_egs=(
-            DATA + "EGS/{interconnect}/specs_EGS.nc"
+            RESOURCES + "{interconnect}/specs_EGS_s{simpl}.nc"
             if "EGS" in config["electricity"]["extendable_carriers"]["Generator"]
             else []
         ),
         profile_egs=(
-            DATA + "EGS/{interconnect}/profile_EGS.nc"
+            RESOURCES + "{interconnect}/profile_EGS_s{simpl}.nc"
             if "EGS" in config["electricity"]["extendable_carriers"]["Generator"]
             else []
         ),
@@ -782,6 +782,28 @@ rule aggregate_to_substations:
         "../scripts/aggregate_to_substations.py"
 
 
+if "EGS" in config["electricity"]["extendable_carriers"]["Generator"]:
+
+    rule aggregate_egs:
+        input:
+            specs=DATA + "EGS/{interconnect}/specs_EGS.nc",
+            profile=DATA + "EGS/{interconnect}/profile_EGS.nc",
+            busmap=RESOURCES + "{interconnect}/busmap_s{simpl}.csv",
+        output:
+            specs=RESOURCES + "{interconnect}/specs_EGS_s{simpl}.nc",
+            profile=RESOURCES + "{interconnect}/profile_EGS_s{simpl}.nc",
+        log:
+            LOGS + "{interconnect}/aggregate_egs_s{simpl}.log",
+        threads: 1
+        resources:
+            mem_mb=lambda wildcards, input, attempt: (input.size // 200000)
+            * attempt
+            * 2,
+            walltime=config_provider("walltime", "aggregate_egs", default="01:00:00"),
+        script:
+            "../scripts/aggregate_egs.py"
+
+
 rule cluster_simpl:
     params:
         aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
@@ -799,6 +821,7 @@ rule cluster_simpl:
         + "{interconnect}/Geospatial/regions_onshore_s{simpl}.geojson",
         regions_offshore=RESOURCES
         + "{interconnect}/Geospatial/regions_offshore_s{simpl}.geojson",
+        busmap=RESOURCES + "{interconnect}/busmap_s{simpl}.csv",
     log:
         "logs/cluster_simpl/{interconnect}/elec_s{simpl}.log",
     threads: 1

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -676,26 +676,11 @@ def attach_egs(
             getattr(input_profiles, "profile_egs"),
         ) as ds_profile,
     ):
-        bus2sub = (
-            pd.read_csv(input_profiles.bus2sub, dtype=str)
-            .drop("interconnect", axis=1)
-            .rename(columns={"Bus": "bus_id"})
-        )
-        # bus2sub stores sub_id as float strings (e.g. "39763.0") while the
-        # EGS profile stores sub_id as integer strings (e.g. "39763").
-        # Normalize to integer strings so the merge key matches.
-        bus2sub["sub_id"] = bus2sub["sub_id"].apply(lambda x: str(int(float(x))))
-
-        # IGNORE: Remove dropna(). Rather, apply dropna when creating the original dataset
-        df_specs = pd.merge(
-            ds_specs.to_dataframe().reset_index().dropna(),
-            bus2sub,
-            on="sub_id",
-            how="left",
-        )
+        # After aggregate_egs runs, the ``sub_id`` dimension contains the
+        # simpl-cluster bus IDs already, so it can be used as ``bus_id`` directly.
+        df_specs = ds_specs.to_dataframe().reset_index().dropna()
+        df_specs = df_specs.rename(columns={"sub_id": "bus_id"})
         df_specs["bus_id"] = df_specs["bus_id"].astype(str)
-
-        # bus_id must be in index for pypsa to read it
         df_specs = df_specs.set_index("bus_id")
 
         # columns must be renamed to refer to the right quantities for pypsa to read it correctly
@@ -729,13 +714,9 @@ def attach_egs(
             p_nom_max_bus = df_q["p_nom_max"]
             efficiency = df_q["efficiency"]  # for now.
 
-            # IGNORE: Remove dropna(). Rather, apply dropna when creating the original dataset
-            df_q_profile = pd.merge(
-                ds_profile.sel(Quality=q).to_dataframe().dropna().reset_index(),
-                bus2sub,
-                on="sub_id",
-                how="left",
-            )
+            df_q_profile = ds_profile.sel(Quality=q).to_dataframe().dropna().reset_index()
+            df_q_profile = df_q_profile.rename(columns={"sub_id": "bus_id"})
+            df_q_profile["bus_id"] = df_q_profile["bus_id"].astype(str)
             bus_profiles = pd.pivot_table(
                 df_q_profile,
                 columns="bus_id",

--- a/workflow/scripts/aggregate_egs.py
+++ b/workflow/scripts/aggregate_egs.py
@@ -1,0 +1,157 @@
+# BY PyPSA-USA Authors
+"""Remap precomputed EGS supply-curve data from substation to ``{simpl}`` cluster bus.
+
+The EGS dataset (NREL-derived supply curves shipped in ``data/EGS/{interconnect}/``)
+is keyed by ``(sub_id, Quality)`` for specs and ``(sub_id, Quality, year, Date)`` for
+profiles. After the simplify-early refactor the network buses are simpl-cluster IDs,
+not substation IDs, so the substation-keyed EGS data has to be aggregated through
+the ``cluster_simpl`` busmap before ``add_electricity`` can attach it.
+
+Per ``(cluster_bus, Quality)`` group:
+* ``avail_capacity_mw`` → sum of constituent substations' capacities
+* ``capex_usd_kw``, ``advanced_capex_usd_kw``, ``fixed_om`` → capacity-weighted mean
+* ``capacity_factor(year, Date)`` → capacity-weighted mean per timestep
+
+The output schema keeps ``sub_id`` as the dimension name (now containing cluster
+bus IDs) so ``attach_egs`` in :mod:`add_electricity` can consume it with minimal
+changes.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from _helpers import configure_logging
+
+logger = logging.getLogger(__name__)
+
+
+def _weighted_mean(values: pd.Series, weights: pd.Series) -> float:
+    w = weights.sum()
+    if w == 0:
+        return np.nan
+    return float((values * weights).sum() / w)
+
+
+def aggregate_specs(
+    df_specs: pd.DataFrame,
+    busmap: pd.Series,
+) -> pd.DataFrame:
+    """Aggregate (sub_id, Quality) specs to (cluster_bus, Quality)."""
+    df = df_specs.copy()
+    df["sub_id"] = df["sub_id"].astype(str)
+    df["cluster_bus"] = df["sub_id"].map(busmap)
+    df = df.dropna(subset=["cluster_bus"])
+
+    def _reduce(group: pd.DataFrame) -> pd.Series:
+        caps = group["avail_capacity_mw"]
+        return pd.Series(
+            {
+                "avail_capacity_mw": caps.sum(),
+                "capex_usd_kw": _weighted_mean(group["capex_usd_kw"], caps),
+                "advanced_capex_usd_kw": _weighted_mean(
+                    group["advanced_capex_usd_kw"],
+                    caps,
+                ),
+                "fixed_om": _weighted_mean(group["fixed_om"], caps),
+            },
+        )
+
+    agg = (
+        df.groupby(["cluster_bus", "Quality"], group_keys=False)
+        .apply(_reduce)
+        .reset_index()
+        .rename(columns={"cluster_bus": "sub_id"})
+    )
+    return agg
+
+
+def aggregate_profile(
+    df_profile: pd.DataFrame,
+    specs_caps: pd.Series,
+    busmap: pd.Series,
+) -> pd.DataFrame:
+    """Aggregate (sub_id, Quality, year, Date) profile to cluster bus.
+
+    ``specs_caps`` is the per-(sub_id, Quality) capacity used as the weight.
+    """
+    df = df_profile.copy()
+    df["sub_id"] = df["sub_id"].astype(str)
+    df["cluster_bus"] = df["sub_id"].map(busmap)
+    df = df.dropna(subset=["cluster_bus"])
+
+    weights = df.set_index(["sub_id", "Quality"]).index.map(specs_caps)
+    df["weight"] = pd.Series(weights, index=df.index).fillna(0.0)
+    df["weighted_cf"] = df["capacity_factor"] * df["weight"]
+
+    agg = (
+        df.groupby(["cluster_bus", "Quality", "year", "Date"], group_keys=False)[["weighted_cf", "weight"]]
+        .sum()
+        .reset_index()
+    )
+    nonzero = agg["weight"] > 0
+    agg["capacity_factor"] = 0.0
+    agg.loc[nonzero, "capacity_factor"] = agg.loc[nonzero, "weighted_cf"] / agg.loc[nonzero, "weight"]
+
+    agg = agg[["cluster_bus", "Quality", "year", "Date", "capacity_factor"]].rename(
+        columns={"cluster_bus": "sub_id"},
+    )
+    return agg
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "aggregate_egs",
+            interconnect="texas",
+            simpl="50",
+        )
+    configure_logging(snakemake)
+
+    busmap = pd.read_csv(snakemake.input.busmap, index_col=0, dtype=str)
+    busmap.index = busmap.index.astype(str)
+    busmap = busmap.iloc[:, 0]
+    logger.info(
+        "Loaded busmap with %d substations mapping to %d clusters.",
+        len(busmap),
+        busmap.nunique(),
+    )
+
+    with xr.open_dataset(snakemake.input.specs) as ds_specs:
+        df_specs = ds_specs.to_dataframe().reset_index().dropna()
+    agg_specs = aggregate_specs(df_specs, busmap)
+    logger.info(
+        "Aggregated specs: %d (cluster_bus, Quality) rows from %d substation rows.",
+        len(agg_specs),
+        len(df_specs),
+    )
+
+    specs_caps = (
+        agg_specs.set_index(["sub_id", "Quality"])["avail_capacity_mw"]
+        # Use the post-aggregation capacities as weights so re-running the
+        # aggregation against the output reproduces it (idempotent).
+    )
+    # For profile weighting we need the PRE-aggregation per-(sub_id, Quality)
+    # capacity. Rebuild it from the original dataframe.
+    pre_caps = df_specs.assign(sub_id=df_specs["sub_id"].astype(str)).set_index(["sub_id", "Quality"])[
+        "avail_capacity_mw"
+    ]
+
+    with xr.open_dataset(snakemake.input.profile) as ds_profile:
+        df_profile = ds_profile.to_dataframe().reset_index().dropna()
+    agg_profile = aggregate_profile(df_profile, pre_caps, busmap)
+    logger.info(
+        "Aggregated profile: %d rows (cluster_bus x Quality x time).",
+        len(agg_profile),
+    )
+
+    out_specs = agg_specs.set_index(["sub_id", "Quality"]).to_xarray()
+    out_specs.to_netcdf(snakemake.output.specs)
+
+    out_profile = agg_profile.set_index(
+        ["sub_id", "Quality", "year", "Date"],
+    )[["capacity_factor"]].to_xarray()
+    out_profile.to_netcdf(snakemake.output.profile)

--- a/workflow/scripts/cluster_simpl.py
+++ b/workflow/scripts/cluster_simpl.py
@@ -22,6 +22,7 @@ will raise if selected.
 import logging
 
 import geopandas as gpd
+import pandas as pd
 import pypsa
 from _helpers import configure_logging, update_p_nom_max
 from cluster_network import cluster_regions, clustering_for_n_clusters
@@ -66,13 +67,21 @@ if __name__ == "__main__":
             aggregation_strategies=params.aggregation_strategies,
             weighting_strategy="population",
         )
+        busmap = clustering.busmap
         n = clustering.network
 
-        cluster_regions((clustering.busmap,), snakemake.input, snakemake.output)
+        cluster_regions((busmap,), snakemake.input, snakemake.output)
     else:
         for which in ("regions_onshore", "regions_offshore"):
             regions = gpd.read_file(getattr(snakemake.input, which))
             regions.to_file(getattr(snakemake.output, which))
+        busmap = pd.Series(n.buses.index, index=n.buses.index, name="cluster_bus")
+
+    busmap.index = busmap.index.astype(str)
+    busmap = busmap.astype(str)
+    busmap.index.name = "sub_id"
+    busmap.name = "cluster_bus"
+    busmap.to_csv(snakemake.output.busmap)
 
     update_p_nom_max(n)
 


### PR DESCRIPTION
## Summary
Continues the stack: this is the third step after [#8](https://github.com/ktehranchi/pypsa-usa/pull/8) (split `simplify_network`) and [#9](https://github.com/ktehranchi/pypsa-usa/pull/9) (move simplify ahead of demand/RE). Base of this PR is `claude/simplify-refactor-phase2`; review on top of #9.

After Phase 1+2 the network at `elec_s{simpl}.nc` is keyed by simpl-cluster bus IDs, but the precomputed NREL EGS supply curves are keyed by substation IDs. `attach_egs`'s `bus2sub` join no longer resolves to network buses, so EGS generators were silently failing to attach. This PR plumbs an explicit aggregation step between `cluster_simpl` and `add_electricity`.

## Changes
- **`cluster_simpl.py`** — exports `busmap_s{simpl}.csv` (sub_id → cluster_bus). Pass-through case (`{simpl}=""`) writes an identity busmap so downstream aggregation works either way.
- **`workflow/scripts/aggregate_egs.py`** (new) — remaps the `(sub_id, Quality)` specs and `(sub_id, Quality, year, Date)` profile through the busmap:
  - `avail_capacity_mw` → sum
  - `capex_usd_kw`, `advanced_capex_usd_kw`, `fixed_om` → capacity-weighted mean
  - `capacity_factor` → capacity-weighted mean per timestep (pre-aggregation per-substation capacities used as weights)
  - Output schema keeps `sub_id` as the dimension name — its values are now cluster bus IDs.
- **`build_electricity.smk`** — new `aggregate_egs` rule gated on `EGS in extendable_carriers.Generator` (matching the existing `retrieve_egs` gate). New `busmap` output on `cluster_simpl`. `add_electricity`'s `specs_egs`/`profile_egs` inputs repointed at the new `s{simpl}` artifacts.
- **`add_electricity.py::attach_egs`** — drops the `bus2sub` merge; uses `sub_id` directly as `bus_id` since post-aggregation it *is* the cluster bus. About 20 lines simpler.

## Test plan
- [x] Ruff clean on all four touched files; pre-commit (snakefmt, ruff format, blackdoc, pyupgrade) passes.
- [x] `snakemake -n` resolves end-to-end DAG for `resources/Default/texas/elec_s50_l_pp.pkl` — `retrieve_egs → cluster_simpl → aggregate_egs → add_electricity` chain wires correctly with `interconnect=texas`, `simpl=50`.
- [ ] End-to-end run on a real `texas` build to confirm EGS generators attach and counts match expectations.
- [ ] Spot-check that capacity-weighted CF aggregation produces sensible values vs. a manual aggregation on a small subset.
- [ ] Verify pass-through (`{simpl}=""`) path: identity busmap → aggregate_egs is a no-op rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)