### PR TITLE
Tier A: static checks (DAG dry-run, path validator, config-keys)

### DIFF
--- a/tests/static/test_config_keys.py
+++ b/tests/static/test_config_keys.py
@@ -1,0 +1,150 @@
+"""Tier A — assert every snakemake.config[...] access in scripts is defined.
+
+AST-walks every script under workflow/scripts/, extracts subscript chains
+rooted at ``snakemake.config`` and asserts each key path exists in the
+merged default config. Catches dead/typo'd config keys (the class of bug
+fixed in PR #10).
+
+Canonical config templates live under ``workflow/repo_data/config/`` and
+are copied into ``workflow/config/`` by ``init_pypsa_usa.sh``. The latter
+also contains the committed ``config.common.yaml`` override. For maximum
+coverage we merge the canonical templates and then overlay any tracked
+runtime overrides on top.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / "workflow"
+SCRIPT_DIR = WORKFLOW_DIR / "scripts"
+REPO_DATA_CONFIG_DIR = WORKFLOW_DIR / "repo_data" / "config"
+RUNTIME_CONFIG_DIR = WORKFLOW_DIR / "config"
+
+# Merge order matches the configfile chain in workflow/Snakefile plus
+# config.default.yaml (the maximal scenario config). config.tutorial.yaml
+# is intentionally omitted — it's a minimal opt-in subset used for fast
+# DAG smoke tests, not a key-vocabulary source of truth.
+DEFAULT_CONFIGFILES = [
+    "config.cluster.yaml",
+    "config.common.yaml",
+    "config.plotting.yaml",
+    "config.api.yaml",
+    "config.sector.yaml",
+    "config.default.yaml",
+]
+
+
+def _merge(a: dict, b: dict) -> dict:
+    """Deep-merge b into a; b wins on conflict."""
+    out = dict(a)
+    for k, v in b.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _load_merged_config() -> dict:
+    merged: dict = {}
+    for name in DEFAULT_CONFIGFILES:
+        # Prefer the runtime workflow/config copy if present (it may carry
+        # tracked overrides), otherwise fall back to the canonical template.
+        runtime_path = RUNTIME_CONFIG_DIR / name
+        template_path = REPO_DATA_CONFIG_DIR / name
+        path = runtime_path if runtime_path.exists() else template_path
+        if not path.exists():
+            continue
+        with open(path) as f:
+            merged = _merge(merged, yaml.safe_load(f) or {})
+    return merged
+
+
+def _key_exists(cfg, keys) -> bool:
+    """Walk a list of keys into nested dicts. True if every key is defined."""
+    node = cfg
+    for k in keys:
+        if not isinstance(node, dict) or k not in node:
+            return False
+        node = node[k]
+    return True
+
+
+def _subscript_chain(node):
+    """Return (root_node, [keys]) for chained Subscript nodes, or None."""
+    keys: list[str] = []
+    while isinstance(node, ast.Subscript):
+        idx = node.slice
+        if isinstance(idx, ast.Constant) and isinstance(idx.value, str):
+            keys.append(idx.value)
+        else:
+            return None  # dynamic key — give up
+        node = node.value
+    keys.reverse()
+    return node, keys
+
+
+def _is_snakemake_config(node) -> bool:
+    """True if node is ``snakemake.config``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "config"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "snakemake"
+    )
+
+
+def _extract_config_accesses(source: str) -> list[list[str]]:
+    """Return key paths accessed via ``snakemake.config[...][...]``."""
+    tree = ast.parse(source)
+    accesses: list[list[str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        chain = _subscript_chain(node)
+        if chain is None:
+            continue
+        root, keys = chain
+        if _is_snakemake_config(root) and keys:
+            accesses.append(keys)
+    return accesses
+
+
+@pytest.fixture(scope="module")
+def merged_config() -> dict:
+    return _load_merged_config()
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "script",
+    sorted(SCRIPT_DIR.glob("*.py")),
+    ids=lambda p: p.name,
+)
+def test_referenced_config_keys_exist(script, merged_config):
+    source = script.read_text()
+    try:
+        accesses = _extract_config_accesses(source)
+    except SyntaxError as e:
+        pytest.skip(f"{script.name} has syntax that ast cannot parse: {e}")
+    missing = [keys for keys in accesses if not _key_exists(merged_config, keys)]
+    # Deduplicate identical key paths in the same script.
+    seen: set[tuple[str, ...]] = set()
+    unique_missing = []
+    for keys in missing:
+        t = tuple(keys)
+        if t in seen:
+            continue
+        seen.add(t)
+        unique_missing.append(keys)
+    assert not unique_missing, (
+        f"{script.name}: snakemake.config keys not defined in any "
+        f"workflow/config/*.yaml or workflow/repo_data/config/*.yaml:\n"
+        + "\n".join(f"  config[{']['.join(repr(k) for k in keys)}]" for keys in unique_missing)
+    )

--- a/tests/static/test_dag_dryrun.py
+++ b/tests/static/test_dag_dryrun.py
@@ -1,0 +1,76 @@
+"""Tier A — verify the snakemake DAG resolves on representative configs.
+
+Catches: missing inputs, typo'd rule names, wildcard mismatches, and
+syntactically broken ``.smk`` files. Runs ``snakemake -n`` (dry-run only,
+no rule actually executes).
+
+Snakemake reads scenario configs from ``workflow/config/``. Only
+``config.common.yaml`` is tracked in git; the rest of the configs and
+``policy_constraints/`` static inputs are seeded from
+``workflow/repo_data/config/`` by ``init_pypsa_usa.sh`` at user-init
+time. This test seeds any missing files in a session-scoped fixture so
+it runs cleanly in CI without depending on the init script being run
+ahead of pytest.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[2] / "workflow"
+RUNTIME_CONFIG_DIR = WORKFLOW_DIR / "config"
+TEMPLATE_CONFIG_DIR = WORKFLOW_DIR / "repo_data" / "config"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _seed_runtime_configs():
+    """Mirror ``init_pypsa_usa.sh``: copy any missing scenario configs +
+    ``policy_constraints/`` from ``workflow/repo_data/config/`` into
+    ``workflow/config/`` so ``snakemake -n`` has the inputs it expects.
+    Existing tracked files (e.g. ``config.common.yaml``) are left alone.
+    """
+    if not TEMPLATE_CONFIG_DIR.exists():
+        return
+    RUNTIME_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    for src in TEMPLATE_CONFIG_DIR.iterdir():
+        dst = RUNTIME_CONFIG_DIR / src.name
+        if dst.exists():
+            continue
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "configfile,target",
+    [
+        ("config/config.tutorial.yaml", "cluster_network"),
+        ("config/config.tutorial.yaml", "solve_network"),
+        ("config/config.default.yaml", "cluster_network"),
+    ],
+)
+def test_snakemake_dryrun_resolves(configfile, target):
+    result = subprocess.run(
+        [
+            "snakemake",
+            "-n",
+            "--configfile",
+            configfile,
+            "--until",
+            target,
+            "--quiet",
+        ],
+        cwd=WORKFLOW_DIR,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"snakemake -n failed for {configfile} --until {target}\n"
+        f"stderr:\n{result.stderr}\n"
+        f"stdout (last 50 lines):\n" + "\n".join(result.stdout.splitlines()[-50:])
+    )

--- a/tests/static/test_paths.py
+++ b/tests/static/test_paths.py
@@ -1,0 +1,65 @@
+"""Tier A — assert every rule path uses a category constant and resolves.
+
+After PR #12 reorganized ``resources/`` into category-first subfolders
+(``NETWORKS``, ``BUSMAPS``, ``PROFILES``, ``GEOSPATIAL``, ``COSTS``,
+``PRICES``, ``DEMAND``, ``POWERPLANTS``, ``HEATING_COP``, ``TEMPERATURE``,
+``POPULATION``, ``CO2``), rule inputs/outputs must use these constants
+rather than hard-coded ``RESOURCES + "{interconnect}/..."`` strings.
+This test scans every ``.smk`` file (and the root Snakefile) for the
+forbidden pattern. ``.smk`` files are not pure Python and cannot be AST
+parsed without a Snakemake-aware preprocessor, so we walk the source text
+directly with a regex that matches ``RESOURCES + "<...>"`` concatenations
+where the literal contains ``{interconnect}/``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[2] / "workflow"
+SMK_FILES = list(WORKFLOW_DIR.glob("Snakefile")) + list(
+    WORKFLOW_DIR.glob("rules/*.smk"),
+)
+
+CATEGORY_CONSTANTS = {
+    "NETWORKS",
+    "BUSMAPS",
+    "PROFILES",
+    "GEOSPATIAL",
+    "COSTS",
+    "PRICES",
+    "POWERPLANTS",
+    "DEMAND",
+    "HEATING_COP",
+    "TEMPERATURE",
+    "POPULATION",
+    "CO2",
+}
+
+# Match  RESOURCES + "...{interconnect}/..."  or
+#        RESOURCES + f"...{{interconnect}}/..."  (f-strings escape braces)
+# across a logical concatenation (allowing whitespace / line continuations
+# between the operands). The leading boundary (\b not after a letter) keeps
+# this from matching e.g. ``MY_RESOURCES``.
+HARDCODED_RE = re.compile(
+    r"(?<![A-Za-z0-9_])RESOURCES\s*\+\s*f?\"([^\"]*\{interconnect\}/[^\"]*)\"",
+)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("smk_path", SMK_FILES, ids=lambda p: p.name)
+def test_no_hardcoded_resources_interconnect_paths(smk_path):
+    """RESOURCES + "{interconnect}/..." is forbidden — use a category constant."""
+    source = smk_path.read_text()
+    violations = []
+    for match in HARDCODED_RE.finditer(source):
+        line_no = source.count("\n", 0, match.start()) + 1
+        violations.append((line_no, match.group(1)))
+    assert not violations, (
+        f"{smk_path.name}: found RESOURCES + '{{interconnect}}/...' literals — "
+        f"use a category constant ({', '.join(sorted(CATEGORY_CONSTANTS))}):\n"
+        + "\n".join(f"  line {ln}: {lit!r}" for ln, lit in violations)
+    )

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -257,7 +257,7 @@ rule all:
 rule data_model:
     input:
         expand(
-            RESOURCES
+            NETWORKS
             + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
             **config["scenario"],
         ),

--- a/workflow/config/config.common.yaml
+++ b/workflow/config/config.common.yaml
@@ -6,6 +6,7 @@ renewable:
   dataset: godeeep #atlite or godeeep
   EGS:
     dispatch: baseload # baseload or flexible
+    drilling_cost: base # base or advanced — selects EGS supply-curve capex column
   onwind:
     cutout: era5
     resource:
@@ -173,3 +174,16 @@ offshore_shape:
 offshore_network:
   enable: true # set to true to enable offshore network
   bus_spacing: 25000 # km
+
+# docs :
+# Defaults for the CO2 storage / pipeline-network optionality. Per-scenario
+# configs override; keeping the keys defined here ensures every rule that
+# reads ``config["co2"][...]`` resolves even when a config does not opt in.
+co2:
+  storage: false   # [false, true]
+  network:
+    enable: false   # [false, true]
+    capital_cost: 2736000   # in USD/12-inch diameter/mile
+    marginal_cost: 4   # in USD/tCO2
+    lifetime: 40   # in years
+    discount_rate: 0.07

--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -4,6 +4,7 @@ pudl_path: s3://pudl.catalyst.coop/v2025.5.0
 renewable:
   EGS:
     dispatch: baseload # baseload or flexible
+    drilling_cost: base # base or advanced — selects EGS supply-curve capex column
   onwind:
     cutout: era5
     resource:
@@ -140,6 +141,19 @@ offshore_shape:
 
 offshore_network:
   bus_spacing: 25000 # km
+
+# docs :
+# Defaults for the CO2 storage / pipeline-network optionality. Per-scenario
+# configs override; keeping the keys defined here ensures every rule that
+# reads ``config["co2"][...]`` resolves even when a config does not opt in.
+co2:
+  storage: false   # [false, true]
+  network:
+    enable: false   # [false, true]
+    capital_cost: 2736000   # in USD/12-inch diameter/mile
+    marginal_cost: 4   # in USD/tCO2
+    lifetime: 40   # in years
+    discount_rate: 0.07
 
 # docs :
 # UCAP (Unforced Capacity) calculation based on Forced Outage Rates (FOR)

--- a/workflow/rules/build_sector.smk
+++ b/workflow/rules/build_sector.smk
@@ -3,7 +3,7 @@
 
 def sector_input_files(wildcards):
     input_files = {
-        "network": RESOURCES
+        "network": NETWORKS
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}.nc",
         "tech_costs": RESOURCES
         + f"costs/sector_costs_{config['scenario']['planning_horizons'][0]}.csv",
@@ -16,19 +16,19 @@ def sector_input_files(wildcards):
             + "natural_gas/EIA-StatetoStateCapacity_Feb2024.xlsx",
             "pipeline_shape": DATA + "natural_gas/pipelines.geojson",
             "eia_757": DATA + "natural_gas/EIA-757.csv",
-            "cop_soil_total": RESOURCES
+            "cop_soil_total": HEATING_COP
             + "{interconnect}/cop_soil_total_elec_s{simpl}_c{clusters}.nc",
-            "cop_soil_rural": RESOURCES
+            "cop_soil_rural": HEATING_COP
             + "{interconnect}/cop_soil_rural_elec_s{simpl}_c{clusters}.nc",
-            "cop_soil_urban": RESOURCES
+            "cop_soil_urban": HEATING_COP
             + "{interconnect}/cop_soil_urban_elec_s{simpl}_c{clusters}.nc",
-            "cop_air_total": RESOURCES
+            "cop_air_total": HEATING_COP
             + "{interconnect}/cop_air_total_elec_s{simpl}_c{clusters}.nc",
-            "cop_air_rural": RESOURCES
+            "cop_air_rural": HEATING_COP
             + "{interconnect}/cop_air_rural_elec_s{simpl}_c{clusters}.nc",
-            "cop_air_urban": RESOURCES
+            "cop_air_urban": HEATING_COP
             + "{interconnect}/cop_air_urban_elec_s{simpl}_c{clusters}.nc",
-            "clustered_pop_layout": RESOURCES
+            "clustered_pop_layout": POPULATION
             + "{interconnect}/pop_layout_elec_s{simpl}_c{clusters}.csv",
             "ev_policy": config["sector"]["transport_sector"]["ev_policy"],
             "residential_stock": "repo_data/sectors/residential_stock",
@@ -39,10 +39,7 @@ def sector_input_files(wildcards):
 
     if config["co2"]["storage"] is True:
         input_files.update(
-            {
-                "co2_storage": RESOURCES
-                + "{interconnect}/co2_storage_s{simpl}_{clusters}.csv"
-            }
+            {"co2_storage": CO2 + "{interconnect}/co2_storage_s{simpl}_{clusters}.csv"}
         )
 
     return input_files
@@ -56,7 +53,7 @@ rule add_sectors:
     input:
         unpack(sector_input_files),
     output:
-        network=RESOURCES
+        network=NETWORKS
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
     log:
         "logs/add_sectors/{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.log",

--- a/workflow/rules/solve_electricity.smk
+++ b/workflow/rules/solve_electricity.smk
@@ -20,7 +20,7 @@ rule solve_network:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
     input:
-        network=RESOURCES
+        network=NETWORKS
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
         flowgates="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_ba_NARIS2024.csv",
         safer_reeds="config/policy_constraints/reeds/prm_annual.csv",

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -3,7 +3,7 @@ rule solve_network_validation:
         solving=config["solving"],
         foresight=config["foresight"],
     input:
-        network=RESOURCES
+        network=NETWORKS
         + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
         flowgates="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_ba_NARIS2024.csv",
         safer_reeds="config/policy_constraints/reeds/prm_annual.csv",


### PR DESCRIPTION
## Summary
Three Tier A static checks added under tests/static/:

- **test_dag_dryrun.py** — runs `snakemake -n` against tutorial + default configs to assert DAG resolves; catches typos, missing inputs, wildcard mismatches.
- **test_paths.py** — scans .smk files, asserts no rule uses `RESOURCES + "{interconnect}/..."` literal; must use the category constants (NETWORKS, GEOSPATIAL, etc.). Also fixes the violations surfaced (see commit log).
- **test_config_keys.py** — AST-walks `workflow/scripts/*.py`, asserts every `snakemake.config[...]` key access exists in the merged workflow/config/*.yaml.

## Real bugs surfaced and fixed
- `workflow/Snakefile`, `workflow/rules/build_sector.smk`, `solve_electricity.smk`, `validate.smk` — RESOURCES + "{interconnect}/..." replaced with the right category constant (NETWORKS / HEATING_COP / POPULATION / CO2). The consumers were referencing stale paths that no longer aligned with the producer rules.
- `workflow/config/config.common.yaml` + `workflow/repo_data/config/config.common.yaml` — added top-level `co2:` block (storage + network defaults) and `renewable.EGS.drilling_cost` default. Both keys are accessed unconditionally by .smk rules and scripts; previously a tutorial config (which doesn't opt into them) would crash with a KeyError on a `snakemake -n` dry-run.

## Test plan
- [x] `pytest -m fast` passes in 29s
- [x] All test_paths cases pass (existing violations fixed in this PR)
- [x] All test_dag_dryrun cases pass (DAG resolves on tutorial + default configs)
- [x] All test_config_keys cases pass (57 scripts, no xfails)

## Stacked on
This PR is stacked on #13 (PR 1: test scaffolding). Base will be changed to `v1-epic` once #13 merges.

## Spec
Part of `docs/superpowers/specs/2026-05-21-testing-strategy-design.md` — PR 2 of 5.