### PR TITLE
Tier B fixture: snakemake build + smoke test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,27 @@ TEMPLATE_CONFIG_DIR = WORKFLOW_DIR / "repo_data" / "config"
 DATA_DIRS = [WORKFLOW_DIR / "data", WORKFLOW_DIR / "cutouts", WORKFLOW_DIR / "repo_data"]
 
 
+def pytest_collection_modifyitems(config, items):
+    """Reject pytest-xdist for integration tests.
+
+    The ``built`` session fixture runs snakemake once per session against the
+    shared ``workflow/`` directory. With xdist, each worker is its own
+    session — they would race on ``.snakemake/`` locks, repeat the (slow)
+    snakemake build, and contend on the seeding step that copies templates
+    from ``repo_data/config/``. Until the fixture is refactored to use a
+    truly isolated per-worker workflow dir, refuse to run.
+    """
+    if not any(item.get_closest_marker("integration") for item in items):
+        return
+    workers = getattr(config.option, "numprocesses", None)
+    if workers and workers != 0:
+        pytest.exit(
+            "tests/integration are not safe under pytest-xdist (see conftest "
+            "docstring). Run them without `-n` / `--numprocesses`.",
+            returncode=4,
+        )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _seed_runtime_configs():
     """Mirror ``init_pypsa_usa.sh``: copy any missing scenario configs +
@@ -47,7 +68,13 @@ def _seed_runtime_configs():
 
 @dataclass(frozen=True)
 class BuiltArtifacts:
-    """Paths to the per-stage artifacts produced by the Tier B snakemake build."""
+    """Paths to the per-stage artifacts produced by the Tier B snakemake build.
+
+    The ``interconnect``, ``simpl``, and ``clusters`` defaults MUST match
+    ``workflow/repo_data/config/config.test.yaml``'s ``scenario`` section.
+    If you change one, change both — the smoke test will fail loudly but
+    only after the (slow) build, wasting CI time.
+    """
 
     run_name: str
     base: Path  # resources/{run_name}/
@@ -109,17 +136,28 @@ def built(tmp_path_factory) -> BuiltArtifacts:
         f"run={{name: '{run_name}', shared_cutouts: true}}",
         "-j",
         str(os.cpu_count() or 2),
+        # Force greedy scheduler to avoid the ILP scheduler's cbc dependency
+        # (cbc is shipped non-executable in some envs and causes PermissionError).
         "--scheduler",
         "greedy",
         "--quiet",
     ]
-    result = subprocess.run(
-        cmd,
-        cwd=WORKFLOW_DIR,
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=WORKFLOW_DIR,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired as e:
+        raw_stderr = e.stderr
+        if isinstance(raw_stderr, bytes):
+            raw_stderr = raw_stderr.decode("utf-8", errors="replace")
+        stderr_tail = "\n".join(raw_stderr.splitlines()[-100:]) if raw_stderr else "<no stderr captured>"
+        pytest.fail(
+            f"snakemake build timed out after {e.timeout}s\nstderr (last 100 lines):\n{stderr_tail}",
+        )
     if result.returncode != 0:
         pytest.fail(
             f"snakemake build failed (exit {result.returncode}):\n"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,131 @@
+"""Tier B — session-scoped fixture that runs `snakemake --until cluster_network`
+once per test session and exposes paths to the produced artifacts.
+
+Skipped automatically if required data dirs are missing (lets developers
+run `pytest -m fast` locally without setting up the data deps).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / "workflow"
+RUNTIME_CONFIG_DIR = WORKFLOW_DIR / "config"
+TEMPLATE_CONFIG_DIR = WORKFLOW_DIR / "repo_data" / "config"
+DATA_DIRS = [WORKFLOW_DIR / "data", WORKFLOW_DIR / "cutouts", WORKFLOW_DIR / "repo_data"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _seed_runtime_configs():
+    """Mirror ``init_pypsa_usa.sh``: copy any missing scenario configs +
+    ``policy_constraints/`` from ``workflow/repo_data/config/`` into
+    ``workflow/config/`` so snakemake has the inputs it expects.
+    Existing tracked files (e.g. ``config.common.yaml``) are left alone.
+
+    Duplicated from ``tests/static/test_dag_dryrun.py`` so Tier B works
+    without depending on Tier A collection order.
+    """
+    if not TEMPLATE_CONFIG_DIR.exists():
+        return
+    RUNTIME_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    for src in TEMPLATE_CONFIG_DIR.iterdir():
+        dst = RUNTIME_CONFIG_DIR / src.name
+        if dst.exists():
+            continue
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+
+
+@dataclass(frozen=True)
+class BuiltArtifacts:
+    """Paths to the per-stage artifacts produced by the Tier B snakemake build."""
+
+    run_name: str
+    base: Path  # resources/{run_name}/
+    interconnect: str = "western"
+    simpl: str = "20"
+    clusters: str = "4m"
+
+    @property
+    def elec_b(self) -> Path:
+        """Base electrical network (pre-simplification)."""
+        return self.base / "networks" / self.interconnect / "elec_b.nc"
+
+    @property
+    def elec_s(self) -> Path:
+        """Simplified electrical network (after cluster_simpl)."""
+        return self.base / "networks" / self.interconnect / f"elec_s{self.simpl}.nc"
+
+    @property
+    def elec_s_dem(self) -> Path:
+        """Simplified network with demand attached."""
+        return self.base / "networks" / self.interconnect / f"elec_s{self.simpl}_dem.nc"
+
+    @property
+    def elec_s_l_pp(self) -> Path:
+        """Simplified network with line + powerplant attributes added."""
+        return self.base / "networks" / self.interconnect / f"elec_s{self.simpl}_l_pp.pkl"
+
+    @property
+    def elec_s_c(self) -> Path:
+        """Final clustered network (after cluster_network)."""
+        return self.base / "networks" / self.interconnect / f"elec_s{self.simpl}_c{self.clusters}.nc"
+
+    @property
+    def busmap_s(self) -> Path:
+        """Bus mapping from base -> simplified network."""
+        return self.base / "busmaps" / self.interconnect / f"busmap_s{self.simpl}.csv"
+
+
+@pytest.fixture(scope="session")
+def built(tmp_path_factory) -> BuiltArtifacts:
+    """Run ``snakemake --until cluster_network`` once per session and expose artifact paths.
+
+    Skips the session's integration tests if ``workflow/data``, ``workflow/cutouts``,
+    or ``workflow/repo_data`` are missing — keeps Tier A runnable on bare clones.
+    """
+    missing = [d for d in DATA_DIRS if not d.exists()]
+    if missing:
+        pytest.skip(
+            "Integration tests require populated data dirs; missing: " + ", ".join(str(m) for m in missing),
+        )
+    run_name = f"pytest_{tmp_path_factory.mktemp('run').name}"
+    cmd = [
+        "snakemake",
+        "--until",
+        "cluster_network",
+        "--configfile",
+        "config/config.test.yaml",
+        "--config",
+        f"run={{name: '{run_name}', shared_cutouts: true}}",
+        "-j",
+        str(os.cpu_count() or 2),
+        "--scheduler",
+        "greedy",
+        "--quiet",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=WORKFLOW_DIR,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"snakemake build failed (exit {result.returncode}):\n"
+            f"stderr (last 100 lines):\n" + "\n".join(result.stderr.splitlines()[-100:]),
+        )
+    return BuiltArtifacts(
+        run_name=run_name,
+        base=WORKFLOW_DIR / "resources" / run_name,
+    )

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -1,0 +1,14 @@
+"""Tier B — load each produced artifact and assert shape.
+
+Initial smoke version: one bus-count assertion to prove the fixture
+plumbing works in CI. Later PRs flesh this out with per-stage assertions.
+"""
+
+import pypsa
+import pytest
+
+
+@pytest.mark.integration
+def test_post_cluster_simpl_bus_count(built):
+    n = pypsa.Network(str(built.elec_s))
+    assert len(n.buses) == 20, f"cluster_simpl produced {len(n.buses)} buses, expected 20 (config.test.yaml simpl=20)"

--- a/workflow/repo_data/config/config.test.yaml
+++ b/workflow/repo_data/config/config.test.yaml
@@ -107,37 +107,3 @@ custom_files:
   files_path: ''
   network_name: ''
 
-solving:
-  options:
-    load_shedding: false
-    clip_p_max_pu: 1.e-2
-    noisy_costs: true
-    skip_iterations: true
-    rolling_horizon: false
-    seed: 123
-    track_iterations: false
-    min_iterations: 4
-    max_iterations: 6
-    transmission_losses: 2
-    linearized_unit_commitment: true
-    horizon: 8760
-    assign_all_duals: true
-  solver:
-    name: gurobi
-    options: gurobi-default
-  solver_options:
-    gurobi-default:
-      threads: 4
-      method: 2
-      crossover: 0
-      BarHomogeneous: 1
-      BarConvTol: 1.e-5
-      OptimalityTol: 1.e-4
-      FeasibilityTol: 1.e-3
-      ScaleFlag: 1
-      Seed: 123
-      AggFill: 0
-      PreDual: 0
-      GURO_PAR_BARDENSETHRESH: 200
-  mem: 30000
-  walltime: "12:00:00"

--- a/workflow/repo_data/config/config.test.yaml
+++ b/workflow/repo_data/config/config.test.yaml
@@ -1,0 +1,143 @@
+# PyPSA-USA test config — used by tests/integration to build to
+# cluster_network on a minimal CA-only Western slice in <5 minutes.
+# DO NOT use as a user-facing entry point.
+run:
+  name: "test"
+  disable_progressbar: true
+  shared_resources: false
+  shared_cutouts: true
+  validation: false
+
+foresight: 'perfect'
+
+scenario:
+  interconnect: [western]
+  clusters: [4m]
+  simpl: [20]
+  opts: [REM-3h]
+  ll: [v1.0]
+  scope: "total"
+  sector: ""
+  planning_horizons: [2030]
+
+model_topology:
+  transmission_network: 'reeds'
+  topological_boundaries: 'reeds_zone'
+  interface_transmission_limits: false
+  include:
+    reeds_state: ['CA']
+  aggregate: {}
+
+enable:
+  build_cutout: false
+
+renewable_weather_years: [2019]
+
+snapshots:
+  start: "2019-01-01 00:00"
+  end: "2019-01-01 23:00"
+  inclusive: both
+
+electricity:
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, geothermal, biomass, waste]
+  renewable_carriers: [onwind, solar, hydro]
+  retirement: economic
+  extendable_carriers:
+    Generator: [solar, onwind, OCGT, CCGT]
+    StorageUnit: [4hr_battery_storage]
+    Store: []
+    Link: []
+  demand:
+    profile: efs
+    scenario:
+      efs_case: reference
+      efs_speed: moderate
+      aeo: reference
+
+conventional:
+  unit_commitment: false
+  must_run: false
+  dynamic_fuel_price:
+    enable: false
+    pudl: true
+    wholesale: true
+
+lines:
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  max_extension: 20000
+  length_factor: 1.25
+
+links:
+  p_max_pu: 1.0
+  p_nom_max: .inf
+  max_extension: 20000
+
+costs:
+  ng_fuel_year: 2019
+
+clustering:
+  simplify_network:
+    algorithm: kmeans
+  cluster_network:
+    algorithm: kmeans
+    exclude_carriers: []
+    consider_efficiency_classes: false
+  aggregation_strategies:
+    generators:
+      build_year: 'capacity_weighted_average'
+      lifetime: 'capacity_weighted_average'
+      start_up_cost: 'capacity_weighted_average'
+      min_up_time: 'capacity_weighted_average'
+      min_down_time: 'capacity_weighted_average'
+      ramp_limit_up: max
+      ramp_limit_down: max
+      committable: any
+      vom_cost: mean
+      fuel_cost: mean
+      heat_rate: mean
+  temporal:
+    resolution_elec: false
+    resolution_sector: false
+
+focus_weights:
+
+custom_files:
+  activate: false
+  files_path: ''
+  network_name: ''
+
+solving:
+  options:
+    load_shedding: false
+    clip_p_max_pu: 1.e-2
+    noisy_costs: true
+    skip_iterations: true
+    rolling_horizon: false
+    seed: 123
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+    transmission_losses: 2
+    linearized_unit_commitment: true
+    horizon: 8760
+    assign_all_duals: true
+  solver:
+    name: gurobi
+    options: gurobi-default
+  solver_options:
+    gurobi-default:
+      threads: 4
+      method: 2
+      crossover: 0
+      BarHomogeneous: 1
+      BarConvTol: 1.e-5
+      OptimalityTol: 1.e-4
+      FeasibilityTol: 1.e-3
+      ScaleFlag: 1
+      Seed: 123
+      AggFill: 0
+      PreDual: 0
+      GURO_PAR_BARDENSETHRESH: 200
+  mem: 30000
+  walltime: "12:00:00"


### PR DESCRIPTION
## Summary
- Adds `workflow/repo_data/config/config.test.yaml` — minimal CA-only Western slice (simpl=20, clusters=4m, 1-day snapshots, 2030 horizon) sized for <5 min builds. Placed under `repo_data/config/` (not directly under `workflow/config/`) to mirror the seeding pattern used for the other tracked config templates — the autouse seeding fixture copies it into `workflow/config/` at test time.
- Adds `tests/integration/conftest.py` with session-scoped `built` fixture that runs `snakemake --until cluster_network` once per session. Skips gracefully when `data/`/`cutouts/`/`repo_data/` aren't populated. Uses `--scheduler greedy` to avoid snakemake's ILP-based scheduler (which requires CBC, not present in all envs).
- Adds one placeholder smoke assertion (`test_post_cluster_simpl_bus_count`) — PR 4 fleshes out the full per-stage assertion suite.

## Test plan
- [x] `snakemake -n --configfile config/config.test.yaml --until cluster_network` resolves (exit 0)
- [ ] `pytest -m integration` builds and passes locally (build kicked off correctly on a worktree with `data/` symlinked from main checkout, but `retrieve_databundles` hung — likely missing pre-cached zenodo bundle for this scenario combo; not a plumbing bug)
- [x] `pytest -m fast` still passes (78 passed / 9 skipped — no Tier A regression)
- [x] On a machine without populated data dirs, `pytest -m integration` SKIPS gracefully with a clear message

## Stacked on
This PR is stacked on #14 (PR 2: Tier A). Base will be changed to `v1-epic` once #13 + #14 merge.

## Spec
Part of `docs/superpowers/specs/2026-05-21-testing-strategy-design.md` — PR 3 of 5.