### PR TITLE
CI: replace ./test.sh with fast-tests + e2e-tests jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,55 +4,44 @@
 
 name: CI
 
-# Caching method based on and described by:
-# epassaro (2021): https://dev.to/epassaro/caching-anaconda-environments-in-github-actions-5hde
-# and code in GitHub repo: https://github.com/epassaro/cache-conda-envs
-
 on:
   push:
     branches:
     - master
+    - v1-epic
   pull_request:
     branches:
     - master
+    - v1-epic
   schedule:
-  - cron: "0 5 * * TUE"
+  - cron: "0 5 * * TUE"    # weekly upstream-master regression
 
 env:
   DATA_CACHE_NUMBER: 2
 
 jobs:
-  build:
+  fast-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install test extras
+      run: pip install -e '.[test]'
+    - name: Run Tier A (static checks)
+      run: pytest -m fast --tb=short -ra
 
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-        # - windows-latest
-        inhouse:
-        # - stable
-        - master
-        exclude:
-        - os: macos-latest
-          inhouse: master
-        - os: windows-latest
-          inhouse: master
-    runs-on: ${{ matrix.os }}
-
+  e2e-tests:
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
-
     steps:
-    - uses: actions/checkout@v3
-
+    - uses: actions/checkout@v4
     - name: Setup secrets
       run: |
         echo -ne "url: ${CDSAPI_URL}\nkey: ${CDSAPI_TOKEN}\n" > ~/.cdsapirc
-
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
@@ -62,34 +51,49 @@ jobs:
         init-shell: bash
         cache-environment: true
         cache-downloads: true
-
-    - name: Install inhouse packages
-      run: |
-        pip install git+https://github.com/PyPSA/atlite.git@master git+https://github.com/PyPSA/powerplantmatching.git@master git+https://github.com/PyPSA/linopy.git@master
-      if: ${{ matrix.inhouse }} == 'master'
-
     - name: Set cache dates
-      run: |
-        echo "WEEK=$(date +'%Y%U')" >> $GITHUB_ENV
-
+      run: echo "WEEK=$(date +'%Y%U')" >> $GITHUB_ENV
     - name: Cache data and cutouts folders
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           data
           cutouts
         key: data-cutouts-${{ env.WEEK }}-${{ env.DATA_CACHE_NUMBER }}
-
-    - name: Test snakemake workflow
-      run: ./test.sh
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4.3.0
+    - name: Install test extras into the conda env
+      run: pip install -e '.[test]'
+    - name: Run Tier B (integration build)
+      run: pytest -m integration --tb=short -ra
+    - name: Upload artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
       with:
-        name: resources-results
+        name: failed-resources
         path: |
-          resources
-          results
+          workflow/resources
+          workflow/logs
         if-no-files-found: warn
-        retention-days: 1
-      if: matrix.os == 'ubuntu' && matrix.inhouse == 'stable'
+        retention-days: 3
+
+  upstream-regression:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: workflow/envs/environment.yaml
+        cache-environment: true
+    - name: Install upstream PyPSA / atlite / linopy from master
+      run: |
+        pip install \
+          git+https://github.com/PyPSA/atlite.git@master \
+          git+https://github.com/PyPSA/powerplantmatching.git@master \
+          git+https://github.com/PyPSA/linopy.git@master
+    - name: Install test extras
+      run: pip install -e '.[test]'
+    - name: Run all tests
+      run: pytest -ra


### PR DESCRIPTION
## Summary
- Splits the existing single CI job into `fast-tests` (no data deps, ~1 min wall-clock) and `e2e-tests` (cached data, ~10 min wall-clock).
- Both jobs run on every push/PR to `master` and `v1-epic`.
- New weekly Tuesday cron `upstream-regression` continues testing against upstream master of PyPSA/atlite/linopy (moved out of the per-PR matrix).
- Removes the broken `./test.sh` step (the file does not exist in the repo - silently a no-op until now).

## Post-merge action REQUIRED
Manually mark `fast-tests` and `e2e-tests` as **required status checks** in branch protection settings for `master` and `v1-epic`:
- Settings -> Branches -> Branch protection rules -> edit rule
- "Require status checks to pass before merging" -> add `fast-tests` and `e2e-tests`

Until that toggle is flipped, the jobs run but are advisory.

## Test plan
- [x] YAML parses
- [x] `pytest -m fast` still passes locally
- [ ] First CI run on this PR shows both `fast-tests` and `e2e-tests` jobs green
- [ ] `e2e-tests` wall-clock < 15 min on cold-cache CI runner
- [ ] `e2e-tests` wall-clock < 5 min on warm-cache CI runner

## Stacked on
This PR is stacked on #16 (PR 4: Tier B full assertions). Base will be changed to `v1-epic` once #13, #14, #15, #16 merge.

## Spec
Part of `docs/superpowers/specs/2026-05-21-testing-strategy-design.md` - PR 5 of 5.